### PR TITLE
Allow . as a relative path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 UNRELEASED:
-        * Remove the 'validity' flag
+
+  * Allow "." as a valid relative dir path with the following rules:
+    * "./" </> "./" = "./"
+    * "./" </> "x/" = "x/"
+    * "x/" </> "./" = "x/"
+    * dirname "x" = "./"
+    * dirname "/" = "./"
+    * dirname "./" = "./"
+  * Remove the 'validity' flag
+
 0.5.13:
 	* Add QuasiQuoters absdir, reldir, absfile, relfile
 0.5.11:

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -285,7 +285,7 @@ filename (Path l) =
 -- @dirname (p \<\/> a) == dirname a@
 --
 dirname :: Path b Dir -> Path Rel Dir
-dirname (Path []) = Path []
+dirname (Path "") = Path ""
 dirname (Path l) =
   Path (last (FilePath.splitPath l))
 

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -286,8 +286,8 @@ filename (Path l) =
 --
 dirname :: Path b Dir -> Path Rel Dir
 dirname (Path "") = Path ""
-dirname (Path l) =
-  Path (last (FilePath.splitPath l))
+dirname (Path l) | FilePath.isDrive l = Path ""
+dirname (Path l) = Path (last (FilePath.splitPath l))
 
 -- | Get extension from given file path.
 --

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -47,7 +47,6 @@ instance Validity (Path Rel Dir) where
     =  FilePath.isRelative fp
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
-    && not (null fp)
     && fp /= "."
     && not (hasParentDir fp)
     && (parseRelDir fp == Just p)

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -90,7 +90,8 @@ shrinkValidRelFile :: Path Rel File -> [Path Rel File]
 shrinkValidRelFile = shrinkValidWith parseRelFile
 
 shrinkValidRelDir :: Path Rel Dir -> [Path Rel Dir]
-shrinkValidRelDir = shrinkValidWith parseRelDir
+shrinkValidRelDir (Path []) = []
+shrinkValidRelDir p = shrinkValidWith parseRelDir p
 
 shrinkValidWith :: (FilePath -> Maybe (Path a b)) -> Path a b -> [Path a b]
-shrinkValidWith fun p = mapMaybe fun $ shrink (toFilePath p)
+shrinkValidWith fun (Path s) = mapMaybe fun $ shrink s

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -43,13 +43,13 @@ instance Validity (Path Abs Dir) where
     && (parseAbsDir fp == Just p)
 
 instance Validity (Path Rel Dir) where
-  isValid p@(Path fp)
-    =  FilePath.isRelative fp
+  isValid p =
+    FilePath.isRelative fp
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
-    && fp /= "."
     && not (hasParentDir fp)
     && (parseRelDir fp == Just p)
+    where fp = toFilePath p
 
 instance GenUnchecked (Path Abs File) where
   genUnchecked = Path <$> genFilePath
@@ -93,4 +93,4 @@ shrinkValidRelDir :: Path Rel Dir -> [Path Rel Dir]
 shrinkValidRelDir = shrinkValidWith parseRelDir
 
 shrinkValidWith :: (FilePath -> Maybe (Path a b)) -> Path a b -> [Path a b]
-shrinkValidWith fun (Path s) = mapMaybe fun $ shrink s
+shrinkValidWith fun p = mapMaybe fun $ shrink (toFilePath p)

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -70,8 +70,9 @@ operationDirname = do
     (dirname ($(mkRelDir "home/chris/") </> $(mkRelDir "bar")) ==
      dirname $(mkRelDir "bar"))
   it
-    "dirname $(mkRelDir .) == $(mkRelDir .)"
-    (dirname $(mkRelDir ".") == $(mkRelDir "."))
+    "dirname / must be a Rel path"
+    ((parseAbsDir $ show $ dirname (fromJust (parseAbsDir "/"))
+     :: Maybe (Path Abs Dir)) == Nothing)
 
 -- | The 'filename' operation.
 operationFilename :: Spec

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -74,7 +74,7 @@ operationIsParentOf = do
      it "isParentOf parent (parent </> child)" $
         forAllShrink genValid shrinkValidAbsDir $ \parent ->
             forAllShrink genValid shrinkValidRelDir $ \child ->
-                isParentOf parent (parent </> child)
+                child == Path [] || isParentOf parent (parent </> child)
 
      it "isParentOf parent (parent </> child)" $
         forAllShrink genValid shrinkValidRelDir $ \parent ->
@@ -84,7 +84,7 @@ operationIsParentOf = do
      it "isParentOf parent (parent </> child)" $
         forAllShrink genValid shrinkValidRelDir $ \parent ->
             forAllShrink genValid shrinkValidRelDir $ \child ->
-                isParentOf parent (parent </> child)
+                child == Path [] || isParentOf parent (parent </> child)
 
 -- | The 'stripDir' operation.
 operationStripDir :: Spec
@@ -102,12 +102,14 @@ operationStripDir = do
      it "stripDir parent (parent </> child) = child" $
         forAllShrink genValid shrinkValidAbsDir $ \parent ->
             forAllShrink genValid shrinkValidRelDir $ \child ->
-                stripDir parent (parent </> child) == Just child
+                child == Path []
+                || stripDir parent (parent </> child) == Just child
 
      it "stripDir parent (parent </> child) = child" $
         forAllShrink genValid shrinkValidRelDir $ \parent ->
             forAllShrink genValid shrinkValidRelDir $ \child ->
-                stripDir parent (parent </> child) == Just child
+                child == Path []
+                || stripDir parent (parent </> child) == Just child
 
      it "produces a valid path on when passed a valid absolute file paths" $ do
         producesValidsOnValids2 (stripDir :: Path Abs Dir -> Path Abs File -> Maybe (Path Rel File))

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -23,6 +23,7 @@ spec =
      describe "Parsing: Path Abs File" parseAbsFileSpec
      describe "Parsing: Path Rel File" parseRelFileSpec
      describe "Operations: (</>)" operationAppend
+     describe "Operations: toFilePath" operationToFilePath
      describe "Operations: stripDir" operationStripDir
      describe "Operations: isParentOf" operationIsParentOf
      describe "Operations: parent" operationParent
@@ -37,7 +38,6 @@ restrictions :: Spec
 restrictions =
   do parseFails "..\\"
      parseFails ".."
-     parseFails "."
      parseSucceeds "a.." (Path "a..\\")
      parseSucceeds "..a" (Path "..a\\")
      parseFails "\\.."
@@ -63,6 +63,9 @@ operationDirname = do
     "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
     (dirname ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar")) ==
      dirname $(mkRelDir "bar"))
+  it
+    "dirname $(mkRelDir .) == $(mkRelDir .)"
+    (dirname $(mkRelDir ".") == $(mkRelDir "."))
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -141,10 +144,23 @@ operationAppend =
         ($(mkRelDir "home\\") </>
          $(mkRelDir "chris") ==
          $(mkRelDir "home\\chris"))
+     it ". + . = ."
+        ($(mkRelDir ".\\") </> $(mkRelDir ".") == $(mkRelDir "."))
+     it ". + x = x"
+        ($(mkRelDir ".") </> $(mkRelDir "x") == $(mkRelDir "x"))
+     it "x + . = x"
+        ($(mkRelDir "x") </> $(mkRelDir ".\\") == $(mkRelDir "x"))
      it "RelDir + RelFile = RelFile"
         ($(mkRelDir "home\\") </>
          $(mkRelFile "chris\\test.txt") ==
          $(mkRelFile "home\\chris\\test.txt"))
+
+operationToFilePath :: Spec
+operationToFilePath =
+  do it "toFilePath $(mkRelDir \".\") == \"./\""
+        (toFilePath $(mkRelDir ".") == ".\\")
+     it "show $(mkRelDir \".\") == \"\\\".\\\\\"\""
+        (show $(mkRelDir ".") == "\".\\\"")
 
 -- | Tests for the tokenizer.
 parseAbsDirSpec :: Spec
@@ -169,8 +185,8 @@ parseRelDirSpec =
      -- failing "//" FIXME
      -- succeeding "~/" (Path "~/") -- https://github.com/chrisdone/path/issues/19
      -- failing "\\" FIXME
-     failing ".\\"
-     failing ".\\.\\"
+     succeeding ".\\" (Path "")
+     succeeding ".\\.\\" (Path "")
      failing "\\\\"
      failing "\\\\\\foo\\\\bar\\\\mu\\"
      failing "\\\\\\foo\\\\bar\\\\\\\\mu"

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -66,6 +66,10 @@ operationDirname = do
   it
     "dirname $(mkRelDir .) == $(mkRelDir .)"
     (dirname $(mkRelDir ".") == $(mkRelDir "."))
+  it
+    "dirname C:\\ must be a Rel path"
+    ((parseAbsDir $ show $ dirname (fromJust (parseAbsDir "C:\\"))
+     :: Maybe (Path Abs Dir)) == Nothing)
 
 -- | The 'filename' operation.
 operationFilename :: Spec

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -160,7 +160,7 @@ operationToFilePath =
   do it "toFilePath $(mkRelDir \".\") == \"./\""
         (toFilePath $(mkRelDir ".") == ".\\")
      it "show $(mkRelDir \".\") == \"\\\".\\\\\"\""
-        (show $(mkRelDir ".") == "\".\\\"")
+        (show $(mkRelDir ".") == "\".\\\\\"")
 
 -- | Tests for the tokenizer.
 parseAbsDirSpec :: Spec


### PR DESCRIPTION
The discussion thread that I started for empty path finally boils down to this. A quick look at the changes in the tests will give you an idea about what it means to the library user. Let me know what you think about this. These are all the changes needed except for some doc tweaks if this gets accepted.

It essentially allows us to compose "." with other relative paths:

> > toFilePath $ $(mkRelDir "./") </> $(mkRelDir "./")
> > "./"
> > toFilePath $ $(mkRelDir "./") </> $(mkRelDir "x")
> > "x/"
> > toFilePath $ $(mkRelDir "x") </> $(mkRelDir ".")
> > "x/"

Also dirname "." is "." itself:

> > dirname $(mkRelDir ".") == $(mkRelDir ".")
> > True
