### PR TITLE
Make parent and isParentOf consistent (fixes #33)

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -110,7 +110,7 @@ data PathParseException
   | InvalidAbsFile FilePath
   | InvalidRelFile FilePath
   | Couldn'tStripPrefixDir FilePath FilePath
-  | NoParent FilePath
+  | HasNoParent FilePath
   deriving (Show,Typeable)
 instance Exception PathParseException
 
@@ -348,13 +348,13 @@ isParentOf p l =
 --
 -- @parent (x \<\/> y) == x@
 --
--- Throws `NoParent` for root directory.
+-- Throws `HasNoParent` for root directory.
 --
 parent :: MonadThrow m
        => Path Abs t -> m (Path Abs Dir)
 parent (Path fp) =
   case FilePath.isDrive fp of
-    True  -> throwM (NoParent fp)
+    True  -> throwM (HasNoParent fp)
     False -> return $ Path
                     $ normalizeDir
                     $ FilePath.takeDirectory

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -124,7 +124,7 @@ type PathParseException = PathException
 
 -- | Convert an absolute 'FilePath' to a normalized absolute dir 'Path'.
 --
--- Throws: 'PathParseException' when the supplied path:
+-- Throws: 'InvalidAbsDir' when the supplied path:
 --
 -- * is not an absolute path
 -- * contains a @..@ anywhere in the path
@@ -141,7 +141,7 @@ parseAbsDir filepath =
 
 -- | Convert a relative 'FilePath' to a normalized relative dir 'Path'.
 --
--- Throws: 'PathParseException' when the supplied path:
+-- Throws: 'InvalidRelDir' when the supplied path:
 --
 -- * is not a relative path
 -- * is any of @""@, @.@ or @..@
@@ -162,7 +162,7 @@ parseRelDir filepath =
 
 -- | Convert an absolute 'FilePath' to a normalized absolute file 'Path'.
 --
--- Throws: 'PathParseException' when the supplied path:
+-- Throws: 'InvalidAbsFile' when the supplied path:
 --
 -- * is not an absolute path
 -- * has a trailing path separator
@@ -181,7 +181,7 @@ parseAbsFile filepath =
 
 -- | Convert a relative 'FilePath' to a normalized relative file 'Path'.
 --
--- Throws: 'PathParseException' when the supplied path:
+-- Throws: 'InvalidRelFile' when the supplied path:
 --
 -- * is not a relative path
 -- * has a trailing path separator

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -111,7 +111,7 @@ data PathException
   | InvalidRelDir FilePath
   | InvalidAbsFile FilePath
   | InvalidRelFile FilePath
-  | Couldn'tStripPrefixDir FilePath FilePath
+  | InvalidPrefix FilePath FilePath
   | HasNoParent FilePath
   deriving (Show,Typeable)
 instance Exception PathException
@@ -313,7 +313,7 @@ fromRelFile = toFilePath
 (</>) (Path a) (Path b) = Path (a ++ b)
 
 -- | Strip directory from path, making it relative to that directory.
--- Throws 'Couldn'tStripPrefixDir' if directory is not a parent of the path.
+-- Throws 'InvalidPrefix' if directory is not a parent of the path.
 --
 -- The following properties hold:
 --
@@ -331,8 +331,8 @@ stripDir :: MonadThrow m
          => Path b Dir -> Path b t -> m (Path Rel t)
 stripDir (Path p) (Path l) =
   case stripPrefix p l of
-    Nothing -> throwM (Couldn'tStripPrefixDir p l)
-    Just "" -> throwM (Couldn'tStripPrefixDir p l)
+    Nothing -> throwM (InvalidPrefix p l)
+    Just "" -> throwM (InvalidPrefix p l)
     Just ok -> return (Path ok)
 
 -- | Determine if a directory is a parent of a given path.

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -110,7 +110,7 @@ data PathParseException
   | InvalidAbsFile FilePath
   | InvalidRelFile FilePath
   | Couldn'tStripPrefixDir FilePath FilePath
-  | NoParent
+  | NoParent FilePath
   deriving (Show,Typeable)
 instance Exception PathParseException
 
@@ -353,8 +353,8 @@ isParentOf p l =
 parent :: MonadThrow m
        => Path Abs t -> m (Path Abs Dir)
 parent (Path fp) =
-  case isRootDir fp of
-    True  -> throwM NoParent
+  case FilePath.isDrive fp of
+    True  -> throwM (NoParent fp)
     False -> return $ Path
                     $ normalizeDir
                     $ FilePath.takeDirectory
@@ -382,12 +382,6 @@ dirname (Path l) =
 
 --------------------------------------------------------------------------------
 -- Internal functions
-
--- | On Posix root is always "/" but on windows it could be "C:" or "C:\" etc.
--- So check in a portable manner.
-isRootDir :: FilePath -> Bool
-isRootDir p = p' == FilePath.takeDirectory p'
-    where p' = FilePath.dropTrailingPathSeparator p
 
 curDirNormalizedFP :: FilePath
 curDirNormalizedFP = '.' : [FilePath.pathSeparator]

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -22,12 +22,14 @@ module Path
   ,Rel
   ,File
   ,Dir
+   -- * Exceptions
+  ,PathException(..)
+  ,PathParseException
    -- * Parsing
   ,parseAbsDir
   ,parseRelDir
   ,parseAbsFile
   ,parseRelFile
-  ,PathParseException
   -- * Constructors
   ,mkAbsDir
   ,mkRelDir
@@ -103,8 +105,8 @@ parseJSONWith f x =
        Left e -> fail (show e)
 {-# INLINE parseJSONWith #-}
 
--- | Exception when parsing a location.
-data PathParseException
+-- | Exceptions during path operations
+data PathException
   = InvalidAbsDir FilePath
   | InvalidRelDir FilePath
   | InvalidAbsFile FilePath
@@ -112,7 +114,10 @@ data PathParseException
   | Couldn'tStripPrefixDir FilePath FilePath
   | HasNoParent FilePath
   deriving (Show,Typeable)
-instance Exception PathParseException
+instance Exception PathException
+
+{-# DEPRECATED PathParseException "Please use PathException instead." #-}
+type PathParseException = PathException
 
 --------------------------------------------------------------------------------
 -- Parsers

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -74,13 +74,9 @@ operationParent =
   do it "parent (parent </> child) == parent"
         (parent ($(mkAbsDir "/foo") </>
                     $(mkRelDir "bar")) ==
-         $(mkAbsDir "/foo"))
-     it "parent \"\" == \"\""
-        (parent $(mkAbsDir "/") ==
-         $(mkAbsDir "/"))
-     it "parent (parent \"\") == \"\""
-        (parent (parent $(mkAbsDir "/")) ==
-         $(mkAbsDir "/"))
+         Just $(mkAbsDir "/foo"))
+     it "parent / == _|_"
+        (parent $(mkAbsDir "/") == Nothing)
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec
@@ -95,6 +91,14 @@ operationIsParentOf =
            $(mkRelDir "bar/")
            ($(mkRelDir "bar/") </>
             $(mkRelFile "bob/foo.txt")))
+     it "not (x `isParentOf` x)"
+        (not (isParentOf
+           $(mkRelDir "x")
+           $(mkRelDir "x")))
+     it "not (/ `isParentOf` /)"
+        (not (isParentOf
+           $(mkAbsDir "/")
+           $(mkAbsDir "/")))
 
 -- | The 'stripDir' operation.
 operationStripDir :: Spec


### PR DESCRIPTION
I took a stab at fixing #33. Not sure if we should create another exception type (e.g. `PathOpsException`).
