### PR TITLE
Add version bounds to dependencies

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -7,9 +7,9 @@ license-file:        LICENSE
 author:              Chris Done <chrisdone@fpcomplete.com>
 maintainer:          Chris Done <chrisdone@fpcomplete.com>
 copyright:           2015–2017 FP Complete
-category:            Filesystem
+category:            System, Filesystem
 build-type:          Simple
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 extra-source-files:  README.md, CHANGELOG
 
 flag validity
@@ -18,52 +18,52 @@ flag validity
   description: Enable validity tests.
 
 library
-  hs-source-dirs:    src/
+  hs-source-dirs:    src
   ghc-options:       -Wall -O2
   exposed-modules:   Path, Path.Internal
-  build-depends:     base >= 4 && <5
-                   , exceptions
-                   , filepath < 1.2.0.1 || >= 1.3
-                   , template-haskell
+  build-depends:     aeson
+                   , base       >= 4.7     && < 5
                    , deepseq
-                   , aeson
-                   , hashable >= 1.2 && < 1.3
+                   , exceptions >= 0.4     && < 0.9
+                   , filepath   < 1.2.0.1  || >= 1.3
+                   , hashable   >= 1.2     && < 1.3
+                   , template-haskell
+  default-language:  Haskell2010
 
 test-suite test
-    type: exitcode-stdio-1.0
-    main-is: Main.hs
-    hs-source-dirs: test
-    build-depends: HUnit
-                 , QuickCheck
-                 , aeson
-                 , base
-                 , bytestring
-                 , filepath
-                 , hspec
-                 , mtl
-                 , path
+  type:              exitcode-stdio-1.0
+  main-is:           Main.hs
+  hs-source-dirs:    test
+  build-depends:     aeson
+                   , base       >= 4.7     && < 5
+                   , bytestring
+                   , filepath   < 1.2.0.1  || >= 1.3
+                   , hspec      >= 2.0     && < 3
+                   , mtl        >= 2.0     && < 3
+                   , path
+  default-language:  Haskell2010
 
 test-suite validity-test
-    if !flag(validity)
-      buildable: False
-    type: exitcode-stdio-1.0
-    main-is: ValidityTest.hs
-    other-modules: Path.Gen
-    hs-source-dirs: test
-    if flag(validity)
-      build-depends: HUnit
-                   , QuickCheck
+  if !flag(validity)
+    buildable: False
+  type:              exitcode-stdio-1.0
+  main-is:           ValidityTest.hs
+  other-modules:     Path.Gen
+  hs-source-dirs:    test
+  if flag(validity)
+    build-depends:   QuickCheck
                    , aeson
-                   , base >= 4.9 && < 5
+                   , base       >= 4.9 && < 5
                    , bytestring
-                   , filepath
+                   , filepath   < 1.2.0.1  || >= 1.3
                    , genvalidity >= 0.3 && < 0.4
                    , genvalidity-hspec >= 0.3 && < 0.4
-                   , hspec
-                   , mtl
+                   , hspec      >= 2.0     && < 3
+                   , mtl        >= 2.0     && < 3
                    , path
-                   , validity >= 0.3.1.1 && < 0.4
+                   , validity   >= 0.3.1.1 && < 0.4
+  default-language:  Haskell2010
 
 source-repository head
-    type:     git
-    location: https://github.com/commercialhaskell/path.git
+  type:              git
+  location:          https://github.com/commercialhaskell/path.git

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,7 +13,6 @@ import Data.Maybe
 import Path
 import Path.Internal
 import Test.Hspec
-import Test.QuickCheck
 
 -- | Test suite entry point, returns exit failure if any test fails.
 main :: IO ()


### PR DESCRIPTION
Close #46.

Also drop redundant denpendencies for test suites and align Cabal file for consistency (could not resist!).