### PR TITLE
Allow linebreaks in Validity instances

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,4 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench # --test --flag path:validity
+- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench --test :validity-test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,4 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench --test :validity-test
+- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench --test :validity-test --no-run-tests

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
-flags: {}
+flags:
+  path:
+    validity: true
 extra-deps:
 - genvalidity-0.3.1.0
 - genvalidity-hspec-0.3.1.0

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -19,7 +19,6 @@ instance Validity (Path Abs File) where
     && not (FilePath.hasTrailingPathSeparator fp)
     && FilePath.isValid fp
     && not (".." `isInfixOf` fp)
-    && not (containsLineBreaks fp)
     && (parseAbsFile fp == Just p)
 
 instance Validity (Path Rel File) where
@@ -30,7 +29,6 @@ instance Validity (Path Rel File) where
     && fp /= "."
     && fp /= ".."
     && not (".." `isInfixOf` fp)
-    && not (containsLineBreaks fp)
     && (parseRelFile fp == Just p)
 
 instance Validity (Path Abs Dir) where
@@ -39,7 +37,6 @@ instance Validity (Path Abs Dir) where
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
     && not (".." `isInfixOf` fp)
-    && not (containsLineBreaks fp)
     && (parseAbsDir fp == Just p)
 
 instance Validity (Path Rel Dir) where
@@ -51,12 +48,7 @@ instance Validity (Path Rel Dir) where
     && fp /= "."
     && fp /= ".."
     && not (".." `isInfixOf` fp)
-    && not (containsLineBreaks fp)
     && (parseRelDir fp == Just p)
-
-
-containsLineBreaks :: String -> Bool
-containsLineBreaks s = any (`elem` s) "\n\r"
 
 instance GenUnchecked (Path Abs File) where
   genUnchecked = Path <$> arbitrary


### PR DESCRIPTION
As this appears to fix the validity-test testsuite, run it in CI

See #41 for the decision to allow linebreaks in paths.

Fixes #37, closes #66.