### PR TITLE
Fix validity test when ".." is part of the file or dir name

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -145,7 +145,6 @@ parseRelDir filepath =
      not (null filepath) &&
      filepath /= "." &&
      normalizeFilePath filepath /= curDirNormalizedFP &&
-     filepath /= ".." &&
      FilePath.isValid filepath
      then return (Path (normalizeDir filepath))
      else throwM (InvalidRelDir filepath)
@@ -204,20 +203,7 @@ validRelFile filepath =
     (FilePath.isAbsolute filepath || FilePath.hasTrailingPathSeparator filepath) &&
   not (null filepath) &&
   not (hasParentDir filepath) &&
-  filepath /= "." && filepath /= ".." && FilePath.isValid filepath
-
--- | Helper function: check if the filepath has any parent directories in it.
--- This handles the logic of checking for different path separators on Windows.
-hasParentDir :: FilePath -> Bool
-hasParentDir filepath' =
-     ("/.." `isSuffixOf` filepath) ||
-     ("/../" `isInfixOf` filepath) ||
-     ("../" `isPrefixOf` filepath)
-  where
-    filepath =
-        case FilePath.pathSeparator of
-            '/' -> filepath'
-            x   -> map (\y -> if x == y then '/' else y) filepath'
+  filepath /= "." && FilePath.isValid filepath
 
 --------------------------------------------------------------------------------
 -- Constructors

--- a/src/Path/Internal.hs
+++ b/src/Path/Internal.hs
@@ -4,13 +4,17 @@
 -- | Internal types and functions.
 
 module Path.Internal
-  (Path(..))
+  ( Path(..)
+  , hasParentDir
+  )
   where
 
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (ToJSON (..))
 import Data.Data
 import Data.Hashable
+import Data.List
+import qualified System.FilePath as FilePath
 
 -- | Path of some base and type.
 --
@@ -66,3 +70,17 @@ instance ToJSON (Path b t) where
 
 instance Hashable (Path b t) where
   hashWithSalt n (Path path) = hashWithSalt n path
+
+-- | Helper function: check if the filepath has any parent directories in it.
+-- This handles the logic of checking for different path separators on Windows.
+hasParentDir :: FilePath -> Bool
+hasParentDir filepath' =
+     (filepath' == "..") ||
+     ("/.." `isSuffixOf` filepath) ||
+     ("/../" `isInfixOf` filepath) ||
+     ("../" `isPrefixOf` filepath)
+  where
+    filepath =
+        case FilePath.pathSeparator of
+            '/' -> filepath'
+            x   -> map (\y -> if x == y then '/' else y) filepath'

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -18,7 +18,7 @@ instance Validity (Path Abs File) where
     =  FilePath.isAbsolute fp
     && not (FilePath.hasTrailingPathSeparator fp)
     && FilePath.isValid fp
-    && not (".." `isInfixOf` fp)
+    && not (hasParentDir fp)
     && (parseAbsFile fp == Just p)
 
 instance Validity (Path Rel File) where
@@ -27,8 +27,7 @@ instance Validity (Path Rel File) where
     && not (FilePath.hasTrailingPathSeparator fp)
     && FilePath.isValid fp
     && fp /= "."
-    && fp /= ".."
-    && not (".." `isInfixOf` fp)
+    && not (hasParentDir fp)
     && (parseRelFile fp == Just p)
 
 instance Validity (Path Abs Dir) where
@@ -36,7 +35,7 @@ instance Validity (Path Abs Dir) where
     =  FilePath.isAbsolute fp
     && FilePath.hasTrailingPathSeparator fp
     && FilePath.isValid fp
-    && not (".." `isInfixOf` fp)
+    && not (hasParentDir fp)
     && (parseAbsDir fp == Just p)
 
 instance Validity (Path Rel Dir) where
@@ -46,8 +45,7 @@ instance Validity (Path Rel Dir) where
     && FilePath.isValid fp
     && not (null fp)
     && fp /= "."
-    && fp /= ".."
-    && not (".." `isInfixOf` fp)
+    && not (hasParentDir fp)
     && (parseRelDir fp == Just p)
 
 instance GenUnchecked (Path Abs File) where


### PR DESCRIPTION
1) ".." is valid as an infix but valid not as the only path component. For example,
"x/y..y/x" is valid but "x/../x" is not. This fix allows the former case but
rejects the latter.

2) I also merged the ".." case in `hasParentDir`. Though it is not necessary in case of absolute paths, it does no harm either and we have one unified abstraction for all ".." cases.