### PR TITLE
Add QuasiQuoters `absdir`, `reldir`, `absfile`, and `relfile`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.5.13:
+	* Add QuasiQuoters absdir, reldir, absfile, relfile
 0.5.11:
 	* Add replaceExtension and fileExtension
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ $(mkAbsFile "/home/chris/x.txt")
 $(mkRelFile "chris/x.txt")
 ```
 
+With the [QuasiQuotes](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XQuasiQuotes)
+language extension, paths can be written as follows:
+
+```haskell
+[absdir|/home/chris|]
+[reldir|chris|]
+[absfile|/home/chris/x.txt|]
+[relfile|chris/x.txt|]
+```
+
 These will run at compile-time and underneath use the appropriate parser.
 
 ### Overloaded strings
@@ -273,7 +283,7 @@ Paths now distinguish in the type system whether they are relative or
 absolute. You can’t append two absolute paths, for example:
 
 ```haskell
-λ> $(mkAbsDir "/home/chris") </> $(mkAbsDir "/home/chris")
+λ> [absdir|/home/chris|]</>[absdir|/home/chris|]
 <interactive>:23:31-55:
     Couldn't match type ‘Abs’ with ‘Rel’
 ```
@@ -304,7 +314,7 @@ is simply string concatenation. This is about as predictable as it can get:
 "/home/chris/"
 λ> toFilePath $(mkRelDir "foo//bar")
 "foo/bar/"
-λ> $(mkAbsDir "/home/chris//") </> $(mkRelDir "foo//bar")
+λ> [absdir|/home/chris//|]</>[reldir|foo//bar|]
 "/home/chris/foo/bar/"
 ```
 
@@ -314,9 +324,9 @@ Now that the path type is encoded in the type system, our `</>` operator
 prevents improper appending:
 
 ```haskell
-λ> $(mkAbsDir "/home/chris/") </> $(mkRelFile "foo//bar")
+λ> [absdir|/home/chris/|]</>[relfile|foo//bar|]
 "/home/chris/foo/bar"
-λ> $(mkAbsFile "/home/chris") </> $(mkRelFile "foo//bar")
+λ> [absfile|/home/chris|]</>[relfile|foo//bar|]
 <interactive>:35:1-26:
     Couldn't match type ‘File’ with ‘Dir’
 ```

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -146,6 +146,8 @@ qq quoteExp' =
 --
 -- [absdir|\/home\/chris|]
 -- @
+--
+-- @since 0.5.13
 absdir :: QuasiQuoter
 absdir = qq mkAbsDir
 
@@ -154,6 +156,8 @@ absdir = qq mkAbsDir
 -- @
 -- [absdir|\/home|]\<\/>[reldir|chris|]
 -- @
+--
+-- @since 0.5.13
 reldir :: QuasiQuoter
 reldir = qq mkRelDir
 
@@ -162,6 +166,8 @@ reldir = qq mkRelDir
 -- @
 -- [absfile|\/home\/chris\/foo.txt|]
 -- @
+--
+-- @since 0.5.13
 absfile :: QuasiQuoter
 absfile = qq mkAbsFile
 
@@ -170,6 +176,8 @@ absfile = qq mkAbsFile
 -- @
 -- [absdir|\/home\/chris|]\<\/>[relfile|foo.txt|]
 -- @
+--
+-- @since 0.5.13
 relfile :: QuasiQuoter
 relfile = qq mkRelFile
 

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -36,6 +36,14 @@ module Path
   ,setFileExtension
   -- * QuasiQuoters
   -- | Using the following requires the QuasiQuotes language extension
+  --
+  -- __For Windows users__, the QuasiQuoters are especially benefitial because they
+  -- prevent Haskell from treating @\\@ as an escape character.
+  -- This makes them easier to write.
+  --
+  -- @
+  -- [absfile|C:\\chris\\foo.txt|]
+  -- @
   ,absdir
   ,reldir
   ,absfile

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 -- | Test suite.
 
@@ -29,6 +30,7 @@ spec =
      describe "Operations: dirname" operationDirname
      describe "Restrictions" restrictions
      describe "Aeson Instances" aesonInstances
+     describe "QuasiQuotes" quasiquotes
 
 -- | Restricting the input of any tricks.
 restrictions :: Spec
@@ -269,3 +271,21 @@ aesonInstances =
        decode (LBS.pack "[\"/foo/bar\"]") `shouldBe` (Nothing :: Maybe [Path Rel Dir])
      it "Encoding \"[\"/foo/bar/mu.txt\"]\" should succeed." $
        encode [Path "/foo/bar/mu.txt" :: Path Abs File] `shouldBe` (LBS.pack "[\"/foo/bar/mu.txt\"]")
+
+-- | Test QuasiQuoters. Make sure they work the same as the $(mk*) constructors.
+quasiquotes :: Spec
+quasiquotes =
+  do it "[absdir|/|] == $(mkAbsDir \"/\")"
+       ([absdir|/|] `shouldBe` $(mkAbsDir "/"))
+     it "[absdir|/home|] == $(mkAbsDir \"/home\")"
+       ([absdir|/home|] `shouldBe` $(mkAbsDir "/home"))
+     it "[reldir|foo|] == $(mkRelDir \"foo\")"
+       ([reldir|foo|] `shouldBe` $(mkRelDir "foo"))
+     it "[reldir|foo/bar|] == $(mkRelDir \"foo/bar\")"
+       ([reldir|foo/bar|] `shouldBe` $(mkRelDir "foo/bar"))
+     it "[absfile|/home/chris/foo.txt|] == $(mkAbsFile \"/home/chris/foo.txt\")"
+       ([absfile|/home/chris/foo.txt|] `shouldBe` $(mkAbsFile "/home/chris/foo.txt"))
+     it "[relfile|foo|] == $(mkRelFile \"foo\")"
+       ([relfile|foo|] `shouldBe` $(mkRelFile "foo"))
+     it "[relfile|chris/foo.txt|] == $(mkRelFile \"chris/foo.txt\")"
+       ([relfile|chris/foo.txt|] `shouldBe` $(mkRelFile "chris/foo.txt"))

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 -- | Test suite.
 
@@ -29,6 +30,7 @@ spec =
      describe "Operations: dirname" operationDirname
      describe "Restrictions" restrictions
      describe "Aeson Instances" aesonInstances
+     describe "QuasiQuotes" quasiquotes
 
 -- | Restricting the input of any tricks.
 restrictions :: Spec
@@ -263,3 +265,21 @@ aesonInstances =
        decode (LBS.pack "[\"C:\\foo\\bar\"]") `shouldBe` (Nothing :: Maybe [Path Rel Dir])
      it "Encoding \"[\"C:\\foo\\bar\\mu.txt\"]\" should succeed." $
        encode [Path "C:\\foo\\bar\\mu.txt" :: Path Abs File] `shouldBe` (LBS.pack "[\"C:\\\\foo\\\\bar\\\\mu.txt\"]")
+
+-- | Test QuasiQuoters. Make sure they work the same as the $(mk*) constructors.
+quasiquotes :: Spec
+quasiquotes =
+  do it "[absdir|C:\\|] == $(mkAbsDir \"C:\\\")"
+       ([absdir|C:\|] `shouldBe` $(mkAbsDir "C:\\"))
+     it "[absdir|C:\\chris\\|] == $(mkAbsDir \"C:\\chris\\\")"
+       ([absdir|C:\chris\|] `shouldBe` $(mkAbsDir "C:\\chris\\"))
+     it "[reldir|foo|] == $(mkRelDir \"foo\")"
+       ([reldir|foo|] `shouldBe` $(mkRelDir "foo"))
+     it "[reldir|foo\\bar|] == $(mkRelDir \"foo\\bar\")"
+       ([reldir|foo\bar|] `shouldBe` $(mkRelDir "foo\\bar"))
+     it "[absfile|C:\\chris\\foo.txt|] == $(mkAbsFile \"C:\\chris\\foo.txt\")"
+       ([absfile|C:\chris\foo.txt|] `shouldBe` $(mkAbsFile "C:\\chris\\foo.txt"))
+     it "[relfile|foo.exe|] == $(mkRelFile \"foo.exe\")"
+       ([relfile|foo.exe|] `shouldBe` $(mkRelFile "foo.exe"))
+     it "[relfile|chris\foo.txt|] == $(mkRelFile \"chris\\foo.txt\")"
+       ([relfile|chris\foo.txt|] `shouldBe` $(mkRelFile "chris\\foo.txt"))


### PR DESCRIPTION
Implements #59

I fell in love with this feature request.

This turned out to be a really easy feature to implement,
and it has the advantage of making Path construction shorter.

```haskell
$(mkAbsDir "/home/chris")</> $(mkRelFile "foo.txt")

[absdir|/home/chris|]</>[relfile|foo.txt|]
```

That's a 9 character difference 😄 

This also removes the need for a space after `</>` when it's followed by `$(..)`