### PR TITLE
Move ‘dirname’ and ‘parent’ into ‘MonadThrow’

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
-UNRELEASED:
-        * Remove the 'validity' flag
+0.6.0:
+	* Remove the 'validity' flag
+	* Move dirname and parent functions into MonadThrow, see #18
+	* Expose data constructors of PathParseException
+	* Derived Eq for PathParseException
 0.5.13:
 	* Add QuasiQuoters absdir, reldir, absfile, relfile
 0.5.11:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 # Disable standard build process with MSBuild
 build: off
 
+install:
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
 # In case of unreliable builds try disabling caching.
 cache:
 - "c:\\sr"

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -33,6 +33,7 @@ module Path
   ,stripDir
   ,isParentOf
   ,parent
+  ,fileParent
   ,filename
   ,dirname
   ,fileExtension
@@ -274,6 +275,19 @@ parent path =
   where
     original = FilePath.dropTrailingPathSeparator (toFilePath path)
     new      = FilePath.takeDirectory original
+
+-- | Take the absolute parent directory from the absolute path.
+--
+-- The following properties hold:
+--
+-- @fileParent (x \<\/> y) == x@
+--
+-- As opposed to 'parent', this function will never fail.
+--
+-- @since 0.6.0
+--
+fileParent :: Path Abs File -> Path Abs Dir
+fileParent = fromJust . parent
 
 -- | Extract the file part of a path.
 --

--- a/src/Path.hs
+++ b/src/Path.hs
@@ -42,7 +42,7 @@ module Path
   ,parseRelDir
   ,parseAbsFile
   ,parseRelFile
-  ,PathParseException
+  ,PathParseException(..)
   -- * Conversion
   ,toFilePath
   ,fromAbsDir
@@ -121,7 +121,8 @@ data PathParseException
   | InvalidAbsFile FilePath
   | InvalidRelFile FilePath
   | Couldn'tStripPrefixDir FilePath FilePath
-  deriving (Show,Typeable)
+  | Couldn'tTakeParent FilePath
+  deriving (Show,Typeable,Eq)
 instance Exception PathParseException
 
 
@@ -260,13 +261,19 @@ isParentOf p l =
 --
 -- @parent (x \<\/> y) == x@
 --
--- On the root, getting the parent is idempotent:
+-- __Note__: when applied to the root directory, this function will throw
+-- 'Couldn'tTakeParent'.
 --
--- @parent (parent \"\/\") = \"\/\"@
+-- @since 0.6.0
 --
-parent :: Path Abs t -> Path Abs Dir
-parent (Path fp) =
-  Path (normalizeDir (FilePath.takeDirectory (FilePath.dropTrailingPathSeparator fp)))
+parent :: MonadThrow m => Path Abs t -> m (Path Abs Dir)
+parent path =
+  if original == new
+    then throwM (Couldn'tTakeParent original)
+    else parseAbsDir new
+  where
+    original = FilePath.dropTrailingPathSeparator (toFilePath path)
+    new      = FilePath.takeDirectory original
 
 -- | Extract the file part of a path.
 --
@@ -284,9 +291,13 @@ filename (Path l) =
 --
 -- @dirname (p \<\/> a) == dirname a@
 --
-dirname :: Path b Dir -> Path Rel Dir
-dirname (Path l) =
-  Path (last (FilePath.splitPath l))
+-- __Note__: getting 'dirname' of the root will result in an 'InvalidRelDir'
+-- exception.
+--
+-- @since 0.6.0
+--
+dirname :: MonadThrow m => Path b Dir -> m (Path Rel Dir)
+dirname = parseRelDir . last . FilePath.splitPath . toFilePath
 
 -- | Get extension from given file path.
 --

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -61,14 +61,14 @@ restrictions =
 -- | The 'dirname' operation.
 operationDirname :: Spec
 operationDirname = do
-  it
-    "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkAbsDir "/home/chris/") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
-  it
-    "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkRelDir "home/chris/") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
+  it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)" $ do
+    x <- dirname ($(mkAbsDir "/home/chris/") </> $(mkRelDir "bar"))
+    y <- dirname $(mkRelDir "bar")
+    x `shouldBe` y
+  it "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)" $ do
+    x <- dirname ($(mkRelDir "home/chris/") </> $(mkRelDir "bar"))
+    y <- dirname $(mkRelDir "bar")
+    x `shouldBe` y
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -88,14 +88,11 @@ operationParent :: Spec
 operationParent =
   do it "parent (parent </> child) == parent"
         (parent ($(mkAbsDir "/foo") </>
-                    $(mkRelDir "bar")) ==
+                    $(mkRelDir "bar")) `shouldReturn`
          $(mkAbsDir "/foo"))
-     it "parent \"\" == \"\""
-        (parent $(mkAbsDir "/") ==
-         $(mkAbsDir "/"))
-     it "parent (parent \"\") == \"\""
-        (parent (parent $(mkAbsDir "/")) ==
-         $(mkAbsDir "/"))
+     it "cannot take the parent of the root directory" $
+        parent $(mkAbsDir "/") `shouldThrow`
+          (== Couldn'tTakeParent "/")
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec
@@ -111,6 +108,9 @@ operationIsParentOf =
            $(mkRelDir "bar/")
            ($(mkRelDir "bar/") </>
             $(mkRelFile "bob/foo.txt")))
+
+     it "the root directory is not the parent of itself" $
+        $(mkAbsDir "/") `shouldSatisfy` (not . isParentOf $(mkAbsDir "/"))
 
 -- | The 'stripDir' operation.
 operationStripDir :: Spec

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -33,6 +33,7 @@ spec = parallel $ do
      describe "Operations: stripDir" operationStripDir
      describe "Operations: isParentOf" operationIsParentOf
      describe "Operations: parent" operationParent
+     describe "Operations: fileParent" operationFileParent
      describe "Operations: filename" operationFilename
      describe "Operations: dirname" operationDirname
 
@@ -82,6 +83,12 @@ operationParent = do
 
      it "produces a valid path on when passed a valid directory path" $ do
         producesValidsOnValids (parent :: Path Abs Dir -> Maybe (Path Abs Dir))
+
+-- | The 'fileParent' operation.
+operationFileParent :: Spec
+operationFileParent = do
+     it "produces a valid path on when passed a valid file path" $ do
+        producesValidsOnValids (fileParent :: Path Abs File -> Path Abs Dir)
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -34,6 +34,7 @@ spec = parallel $ do
      describe "Operations: isParentOf" operationIsParentOf
      describe "Operations: parent" operationParent
      describe "Operations: filename" operationFilename
+     describe "Operations: dirname" operationDirname
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -54,14 +55,33 @@ operationFilename = do
      it "produces a valid path on when passed a valid relative path" $ do
         producesValidsOnValids (filename :: Path Rel File -> Path Rel File)
 
+-- | The 'dirname' operation.
+operationDirname :: Spec
+operationDirname = do
+     it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname)" $
+         forAllShrink genValid shrinkValidAbsDir $ \parent ->
+             forAllShrink genValid shrinkValidRelDir $ \dir ->
+                 dirname (parent </> dir) `shouldBe` (dirname dir :: Maybe (Path Rel Dir))
+
+     it "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname)" $
+         forAllShrink genValid shrinkValidRelDir $ \parent ->
+             forAllShrink genValid shrinkValidRelDir $ \dir ->
+                 dirname (parent </> dir) `shouldBe` (dirname dir :: Maybe (Path Rel Dir))
+
+     it "produces a valid path on when passed a valid absolute path" $ do
+        producesValidsOnValids (dirname :: Path Abs Dir -> Maybe (Path Rel Dir))
+
+     it "produces a valid path on when passed a valid relative path" $ do
+        producesValidsOnValids (dirname :: Path Rel Dir -> Maybe (Path Rel Dir))
+
 -- | The 'parent' operation.
 operationParent :: Spec
 operationParent = do
      it "produces a valid path on when passed a valid file path" $ do
-        producesValidsOnValids (parent :: Path Abs File -> Path Abs Dir)
+        producesValidsOnValids (parent :: Path Abs File -> Maybe (Path Abs Dir))
 
      it "produces a valid path on when passed a valid directory path" $ do
-        producesValidsOnValids (parent :: Path Abs Dir -> Path Abs Dir)
+        producesValidsOnValids (parent :: Path Abs Dir -> Maybe (Path Abs Dir))
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -55,14 +55,14 @@ restrictions =
 -- | The 'dirname' operation.
 operationDirname :: Spec
 operationDirname = do
-  it
-    "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkAbsDir "C:\\chris\\") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
-  it
-    "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
+  it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)" $ do
+    x <- dirname ($(mkAbsDir "C:\\chris\\") </> $(mkRelDir "bar"))
+    y <- dirname $(mkRelDir "bar")
+    x `shouldBe` y
+  it "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)" $ do
+    x <- dirname ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar"))
+    y <- dirname $(mkRelDir "bar")
+    x `shouldBe` y
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -82,14 +82,11 @@ operationParent :: Spec
 operationParent =
   do it "parent (parent </> child) == parent"
         (parent ($(mkAbsDir "C:\\foo") </>
-                    $(mkRelDir "bar")) ==
+                    $(mkRelDir "bar")) `shouldReturn`
          $(mkAbsDir "C:\\foo"))
      it "parent \"\" == \"\""
-        (parent $(mkAbsDir "C:\\") ==
-         $(mkAbsDir "C:\\"))
-     it "parent (parent \"\") == \"\""
-        (parent (parent $(mkAbsDir "C:\\")) ==
-         $(mkAbsDir "C:\\"))
+        (parent $(mkAbsDir "C:\\") `shouldThrow`
+          (== Couldn'tTakeParent "C:\\"))
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec
@@ -105,6 +102,9 @@ operationIsParentOf =
            $(mkRelDir "bar\\")
            ($(mkRelDir "bar\\") </>
             $(mkRelFile "bob\\foo.txt")))
+
+     it "the root directory is not the parent of itself" $
+       $(mkAbsDir "C://") `shouldSatisfy` (not . isParentOf $(mkAbsDir "C://"))
 
 -- | The 'stripDir' operation.
 operationStripDir :: Spec


### PR DESCRIPTION
Close #18.