### PR TITLE
restrict kinds for Path data type

### DIFF
--- a/src/Path.hs
+++ b/src/Path.hs
@@ -6,14 +6,13 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
 
 module Path
   (-- * Types
    Path
-  ,Abs
-  ,Rel
-  ,File
-  ,Dir
+  ,PathRelativity(..)
+  ,FileType(..)
   -- * QuasiQuoters
   -- | Using the following requires the QuasiQuotes language extension.
   --
@@ -58,72 +57,13 @@ module Path
   )
   where
 
-import           Control.Exception (Exception)
-import           Control.Monad
 import           Control.Monad.Catch (MonadThrow(..))
-import           Data.Aeson (FromJSON (..))
-import qualified Data.Aeson.Types as Aeson
-import           Data.Data
 import           Data.List
 import           Data.Maybe
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote (QuasiQuoter(..))
 import           Path.Internal
 import qualified System.FilePath as FilePath
-
---------------------------------------------------------------------------------
--- Types
-
--- | An absolute path.
-data Abs deriving (Typeable)
-
--- | A relative path; one without a root. Note that a @.@ as well as any path
--- starting with a @..@ is not a valid relative path. In other words, a
--- relative path is always strictly under the directory tree to which it is
--- relative.
-data Rel deriving (Typeable)
-
--- | A file path.
-data File deriving (Typeable)
-
--- | A directory path.
-data Dir deriving (Typeable)
-
-instance FromJSON (Path Abs File) where
-  parseJSON = parseJSONWith parseAbsFile
-  {-# INLINE parseJSON #-}
-
-instance FromJSON (Path Rel File) where
-  parseJSON = parseJSONWith parseRelFile
-  {-# INLINE parseJSON #-}
-
-instance FromJSON (Path Abs Dir) where
-  parseJSON = parseJSONWith parseAbsDir
-  {-# INLINE parseJSON #-}
-
-instance FromJSON (Path Rel Dir) where
-  parseJSON = parseJSONWith parseRelDir
-  {-# INLINE parseJSON #-}
-
-parseJSONWith :: (Show e, FromJSON a)
-              => (a -> Either e b) -> Aeson.Value -> Aeson.Parser b
-parseJSONWith f x =
-  do fp <- parseJSON x
-     case f fp of
-       Right p -> return p
-       Left e -> fail (show e)
-{-# INLINE parseJSONWith #-}
-
--- | Exception when parsing a location.
-data PathParseException
-  = InvalidAbsDir FilePath
-  | InvalidRelDir FilePath
-  | InvalidAbsFile FilePath
-  | InvalidRelFile FilePath
-  | Couldn'tStripPrefixDir FilePath FilePath
-  deriving (Show,Typeable)
-instance Exception PathParseException
-
 
 --------------------------------------------------------------------------------
 -- QuasiQuoters
@@ -215,7 +155,7 @@ relfile = qq mkRelFile
 --
 -- @x \<\/> $(mkAbsDir …)@
 --
-(</>) :: Path b Dir -> Path Rel t -> Path b t
+(</>) :: Path b 'Dir -> Path 'Rel t -> Path b t
 (</>) (Path a) (Path b) = Path (a ++ b)
 
 -- | Strip directory from path, making it relative to that directory.
@@ -234,7 +174,7 @@ relfile = qq mkRelFile
 -- In other words the bases must match.
 --
 stripDir :: MonadThrow m
-         => Path b Dir -> Path b t -> m (Path Rel t)
+         => Path b 'Dir -> Path b t -> m (Path 'Rel t)
 stripDir (Path p) (Path l) =
   case stripPrefix p l of
     Nothing -> throwM (Couldn'tStripPrefixDir p l)
@@ -250,7 +190,7 @@ stripDir (Path p) (Path l) =
 --
 -- @x \`isParentOf\` (x \<\/\> y)@
 --
-isParentOf :: Path b Dir -> Path b t -> Bool
+isParentOf :: Path b 'Dir -> Path b t -> Bool
 isParentOf p l =
   isJust (stripDir p l)
 
@@ -264,7 +204,7 @@ isParentOf p l =
 --
 -- @parent (parent \"\/\") = \"\/\"@
 --
-parent :: Path Abs t -> Path Abs Dir
+parent :: Path 'Abs t -> Path 'Abs 'Dir
 parent (Path fp) =
   Path (normalizeDir (FilePath.takeDirectory (FilePath.dropTrailingPathSeparator fp)))
 
@@ -274,7 +214,7 @@ parent (Path fp) =
 --
 -- @filename (p \<\/> a) == filename a@
 --
-filename :: Path b File -> Path Rel File
+filename :: Path b 'File -> Path 'Rel 'File
 filename (Path l) =
   Path (FilePath.takeFileName l)
 
@@ -284,14 +224,14 @@ filename (Path l) =
 --
 -- @dirname (p \<\/> a) == dirname a@
 --
-dirname :: Path b Dir -> Path Rel Dir
+dirname :: Path b 'Dir -> Path 'Rel 'Dir
 dirname (Path l) =
   Path (last (FilePath.splitPath l))
 
 -- | Get extension from given file path.
 --
 -- @since 0.5.11
-fileExtension :: Path b File -> String
+fileExtension :: Path b 'File -> String
 fileExtension = FilePath.takeExtension . toFilePath
 
 -- | Replace\/add extension to given file path. Throws if the
@@ -300,112 +240,15 @@ fileExtension = FilePath.takeExtension . toFilePath
 -- @since 0.5.11
 setFileExtension :: MonadThrow m
   => String            -- ^ Extension to set
-  -> Path b File       -- ^ Old file name
-  -> m (Path b File)   -- ^ New file name with the desired extension
+  -> Path b 'File       -- ^ Old file name
+  -> m (Path b 'File)   -- ^ New file name with the desired extension
 setFileExtension ext (Path path) =
   if FilePath.isAbsolute path
-    then liftM coercePath (parseAbsFile (FilePath.replaceExtension path ext))
-    else liftM coercePath (parseRelFile (FilePath.replaceExtension path ext))
+    then fmap coercePath (parseAbsFile (FilePath.replaceExtension path ext))
+    else fmap coercePath (parseRelFile (FilePath.replaceExtension path ext))
   where coercePath :: Path a b -> Path a' b'
         coercePath (Path a) = Path a
 
-
---------------------------------------------------------------------------------
--- Parsers
-
--- | Convert an absolute 'FilePath' to a normalized absolute dir 'Path'.
---
--- Throws: 'PathParseException' when the supplied path:
---
--- * is not an absolute path
--- * contains a @..@ anywhere in the path
--- * is not a valid path (See 'System.FilePath.isValid')
---
-parseAbsDir :: MonadThrow m
-            => FilePath -> m (Path Abs Dir)
-parseAbsDir filepath =
-  if FilePath.isAbsolute filepath &&
-     not (hasParentDir filepath) &&
-     FilePath.isValid filepath
-     then return (Path (normalizeDir filepath))
-     else throwM (InvalidAbsDir filepath)
-
--- | Convert a relative 'FilePath' to a normalized relative dir 'Path'.
---
--- Throws: 'PathParseException' when the supplied path:
---
--- * is not a relative path
--- * is any of @""@, @.@ or @..@
--- * contains @..@ anywhere in the path
--- * is not a valid path (See 'System.FilePath.isValid')
---
-parseRelDir :: MonadThrow m
-            => FilePath -> m (Path Rel Dir)
-parseRelDir filepath =
-  if not (FilePath.isAbsolute filepath) &&
-     not (hasParentDir filepath) &&
-     not (null filepath) &&
-     filepath /= "." &&
-     normalizeFilePath filepath /= curDirNormalizedFP &&
-     FilePath.isValid filepath
-     then return (Path (normalizeDir filepath))
-     else throwM (InvalidRelDir filepath)
-
--- | Convert an absolute 'FilePath' to a normalized absolute file 'Path'.
---
--- Throws: 'PathParseException' when the supplied path:
---
--- * is not an absolute path
--- * has a trailing path separator
--- * contains @..@ anywhere in the path
--- * ends in @/.@
--- * is not a valid path (See 'System.FilePath.isValid')
---
-parseAbsFile :: MonadThrow m
-             => FilePath -> m (Path Abs File)
-parseAbsFile filepath =
-  case validAbsFile filepath of
-    True
-      | normalized <- normalizeFilePath filepath
-      , validAbsFile normalized ->
-        return (Path normalized)
-    _ -> throwM (InvalidAbsFile filepath)
-
--- | Is the string a valid absolute file?
-validAbsFile :: FilePath -> Bool
-validAbsFile filepath =
-  FilePath.isAbsolute filepath &&
-  not (FilePath.hasTrailingPathSeparator filepath) &&
-  not (hasParentDir filepath) &&
-  FilePath.isValid filepath
-
--- | Convert a relative 'FilePath' to a normalized relative file 'Path'.
---
--- Throws: 'PathParseException' when the supplied path:
---
--- * is not a relative path
--- * has a trailing path separator
--- * is @""@, @.@ or @..@
--- * contains @..@ anywhere in the path
--- * is not a valid path (See 'System.FilePath.isValid')
---
-parseRelFile :: MonadThrow m
-             => FilePath -> m (Path Rel File)
-parseRelFile filepath =
-  case validRelFile filepath of
-    True
-      | normalized <- normalizeFilePath filepath
-      , validRelFile normalized -> return (Path normalized)
-    _ -> throwM (InvalidRelFile filepath)
-
--- | Is the string a valid relative file?
-validRelFile :: FilePath -> Bool
-validRelFile filepath =
-  not
-    (FilePath.isAbsolute filepath || FilePath.hasTrailingPathSeparator filepath) &&
-  not (null filepath) &&
-  not (hasParentDir filepath) &&
-  filepath /= "." && FilePath.isValid filepath
 
 --------------------------------------------------------------------------------
 -- Conversion
@@ -419,19 +262,19 @@ toFilePath :: Path b t -> FilePath
 toFilePath (Path l) = l
 
 -- | Convert absolute path to directory to 'FilePath' type.
-fromAbsDir :: Path Abs Dir -> FilePath
+fromAbsDir :: Path 'Abs 'Dir -> FilePath
 fromAbsDir = toFilePath
 
 -- | Convert relative path to directory to 'FilePath' type.
-fromRelDir :: Path Rel Dir -> FilePath
+fromRelDir :: Path 'Rel 'Dir -> FilePath
 fromRelDir = toFilePath
 
 -- | Convert absolute path to file to 'FilePath' type.
-fromAbsFile :: Path Abs File -> FilePath
+fromAbsFile :: Path 'Abs 'File -> FilePath
 fromAbsFile = toFilePath
 
 -- | Convert relative path to file to 'FilePath' type.
-fromRelFile :: Path Rel File -> FilePath
+fromRelFile :: Path 'Rel 'File -> FilePath
 fromRelFile = toFilePath
 
 --------------------------------------------------------------------------------
@@ -447,7 +290,7 @@ mkAbsDir s =
   case parseAbsDir s of
     Left err -> error (show err)
     Right (Path str) ->
-      [|Path $(return (LitE (StringL str))) :: Path Abs Dir|]
+      [|Path $(return (LitE (StringL str))) :: Path 'Abs 'Dir|]
 
 -- | Make a 'Path' 'Rel' 'Dir'.
 mkRelDir :: FilePath -> Q Exp
@@ -455,7 +298,7 @@ mkRelDir s =
   case parseRelDir s of
     Left err -> error (show err)
     Right (Path str) ->
-      [|Path $(return (LitE (StringL str))) :: Path Rel Dir|]
+      [|Path $(return (LitE (StringL str))) :: Path 'Rel 'Dir|]
 
 -- | Make a 'Path' 'Abs' 'File'.
 --
@@ -467,7 +310,7 @@ mkAbsFile s =
   case parseAbsFile s of
     Left err -> error (show err)
     Right (Path str) ->
-      [|Path $(return (LitE (StringL str))) :: Path Abs File|]
+      [|Path $(return (LitE (StringL str))) :: Path 'Abs 'File|]
 
 -- | Make a 'Path' 'Rel' 'File'.
 mkRelFile :: FilePath -> Q Exp
@@ -475,28 +318,4 @@ mkRelFile s =
   case parseRelFile s of
     Left err -> error (show err)
     Right (Path str) ->
-      [|Path $(return (LitE (StringL str))) :: Path Rel File|]
-
-
---------------------------------------------------------------------------------
--- Internal functions
-
-curDirNormalizedFP :: FilePath
-curDirNormalizedFP = '.' : [FilePath.pathSeparator]
-
--- | Internal use for normalizing a directory.
-normalizeDir :: FilePath -> FilePath
-normalizeDir = FilePath.addTrailingPathSeparator . normalizeFilePath
-
-normalizeFilePath :: FilePath -> FilePath
-#if defined(mingw32_HOST_OS) || defined(__MINGW32__) || MIN_VERSION_filepath(1,4,0)
-normalizeFilePath = FilePath.normalise
-#else
-normalizeFilePath = normalizeLeadingSeparators . FilePath.normalise
-    where
-        sep = FilePath.pathSeparator
-        normalizeLeadingSeparators (x1:x2:xs) | x1 == sep && x2 == sep
-            = normalizeLeadingSeparators (sep:xs)
-        normalizeLeadingSeparators x = x
-#endif
-
+      [|Path $(return (LitE (StringL str))) :: Path 'Rel 'File|]

--- a/src/Path/Internal.hs
+++ b/src/Path/Internal.hs
@@ -1,20 +1,54 @@
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 -- | Internal types and functions.
 
 module Path.Internal
   ( Path(..)
+  , PathRelativity(..)
+  , FileType(..)
+  , PathParseException(..)
+  , parseAbsDir
+  , parseAbsFile
+  , parseRelDir
+  , parseRelFile
+  , normalizeDir
+  , normalizeFilePath
   , hasParentDir
   )
   where
 
+import           Control.Exception (Exception)
 import Control.DeepSeq (NFData (..))
-import Data.Aeson (ToJSON (..))
+import           Control.Monad.Catch (MonadThrow(..))
+import           Data.Aeson (FromJSON (..), ToJSON (..))
+import qualified Data.Aeson.Types as Aeson
 import Data.Data
 import Data.Hashable
 import Data.List
 import qualified System.FilePath as FilePath
+
+--------------------------------------------------------------------------------
+-- Types
+
+data PathRelativity
+  -- | An absolute path.
+  = Abs
+
+  -- | A relative path; one without a root. Note that a @.@ as well as
+  -- any path starting with a @..@ is not a valid relative path. In
+  -- other words, a relative path is always strictly under the
+  -- directory tree to which it is relative.
+  | Rel
+  deriving (Typeable)
+
+data FileType
+  = File
+  | Dir
+  deriving (Typeable)
 
 -- | Path of some base and type.
 --
@@ -30,8 +64,18 @@ import qualified System.FilePath as FilePath
 --
 -- All directories end in a trailing separator. There are no duplicate
 -- path separators @\/\/@, no @..@, no @.\/@, no @~\/@, etc.
-newtype Path b t = Path FilePath
+newtype Path (b :: PathRelativity) (t :: FileType) = Path FilePath
   deriving (Typeable)
+
+-- | Exception when parsing a location.
+data PathParseException
+  = InvalidAbsDir FilePath
+  | InvalidRelDir FilePath
+  | InvalidAbsFile FilePath
+  | InvalidRelFile FilePath
+  | Couldn'tStripPrefixDir FilePath FilePath
+  deriving (Show,Typeable)
+instance Exception PathParseException
 
 -- | String equality.
 --
@@ -71,6 +115,128 @@ instance ToJSON (Path b t) where
 instance Hashable (Path b t) where
   hashWithSalt n (Path path) = hashWithSalt n path
 
+--------------------------------------------------------------------------------
+-- Parsers
+
+-- | Convert an absolute 'FilePath' to a normalized absolute dir 'Path'.
+--
+-- Throws: 'PathParseException' when the supplied path:
+--
+-- * is not an absolute path
+-- * contains a @..@ anywhere in the path
+-- * is not a valid path (See 'System.FilePath.isValid')
+--
+parseAbsDir :: MonadThrow m
+            => FilePath -> m (Path 'Abs 'Dir)
+parseAbsDir filepath =
+  if FilePath.isAbsolute filepath &&
+     not (hasParentDir filepath) &&
+     FilePath.isValid filepath
+     then return (Path (normalizeDir filepath))
+     else throwM (InvalidAbsDir filepath)
+
+-- | Convert a relative 'FilePath' to a normalized relative dir 'Path'.
+--
+-- Throws: 'PathParseException' when the supplied path:
+--
+-- * is not a relative path
+-- * is any of @""@, @.@ or @..@
+-- * contains @..@ anywhere in the path
+-- * is not a valid path (See 'System.FilePath.isValid')
+--
+parseRelDir :: MonadThrow m
+            => FilePath -> m (Path 'Rel 'Dir)
+parseRelDir filepath =
+  if not (FilePath.isAbsolute filepath) &&
+     not (hasParentDir filepath) &&
+     not (null filepath) &&
+     filepath /= "." &&
+     normalizeFilePath filepath /= curDirNormalizedFP &&
+     FilePath.isValid filepath
+     then return (Path (normalizeDir filepath))
+     else throwM (InvalidRelDir filepath)
+
+-- | Convert an absolute 'FilePath' to a normalized absolute file 'Path'.
+--
+-- Throws: 'PathParseException' when the supplied path:
+--
+-- * is not an absolute path
+-- * has a trailing path separator
+-- * contains @..@ anywhere in the path
+-- * ends in @/.@
+-- * is not a valid path (See 'System.FilePath.isValid')
+--
+parseAbsFile :: MonadThrow m
+             => FilePath -> m (Path 'Abs 'File)
+parseAbsFile filepath =
+  case validAbsFile filepath of
+    True
+      | normalized <- normalizeFilePath filepath
+      , validAbsFile normalized ->
+        return (Path normalized)
+    _ -> throwM (InvalidAbsFile filepath)
+
+-- | Is the string a valid absolute file?
+validAbsFile :: FilePath -> Bool
+validAbsFile filepath =
+  FilePath.isAbsolute filepath &&
+  not (FilePath.hasTrailingPathSeparator filepath) &&
+  not (hasParentDir filepath) &&
+  FilePath.isValid filepath
+
+-- | Convert a relative 'FilePath' to a normalized relative file 'Path'.
+--
+-- Throws: 'PathParseException' when the supplied path:
+--
+-- * is not a relative path
+-- * has a trailing path separator
+-- * is @""@, @.@ or @..@
+-- * contains @..@ anywhere in the path
+-- * is not a valid path (See 'System.FilePath.isValid')
+--
+parseRelFile :: MonadThrow m
+             => FilePath -> m (Path 'Rel 'File)
+parseRelFile filepath =
+  case validRelFile filepath of
+    True
+      | normalized <- normalizeFilePath filepath
+      , validRelFile normalized -> return (Path normalized)
+    _ -> throwM (InvalidRelFile filepath)
+
+-- | Is the string a valid relative file?
+validRelFile :: FilePath -> Bool
+validRelFile filepath =
+  not
+    (FilePath.isAbsolute filepath || FilePath.hasTrailingPathSeparator filepath) &&
+  not (null filepath) &&
+  not (hasParentDir filepath) &&
+  filepath /= "." && FilePath.isValid filepath
+
+instance FromJSON (Path 'Abs 'File) where
+  parseJSON = parseJSONWith parseAbsFile
+  {-# INLINE parseJSON #-}
+
+instance FromJSON (Path 'Rel 'File) where
+  parseJSON = parseJSONWith parseRelFile
+  {-# INLINE parseJSON #-}
+
+instance FromJSON (Path 'Abs 'Dir) where
+  parseJSON = parseJSONWith parseAbsDir
+  {-# INLINE parseJSON #-}
+
+instance FromJSON (Path 'Rel 'Dir) where
+  parseJSON = parseJSONWith parseRelDir
+  {-# INLINE parseJSON #-}
+
+parseJSONWith :: (Show e, FromJSON a)
+              => (a -> Either e b) -> Aeson.Value -> Aeson.Parser b
+parseJSONWith f x =
+  do fp <- parseJSON x
+     case f fp of
+       Right p -> return p
+       Left e -> fail (show e)
+{-# INLINE parseJSONWith #-}
+
 -- | Helper function: check if the filepath has any parent directories in it.
 -- This handles the logic of checking for different path separators on Windows.
 hasParentDir :: FilePath -> Bool
@@ -84,3 +250,25 @@ hasParentDir filepath' =
         case FilePath.pathSeparator of
             '/' -> filepath'
             x   -> map (\y -> if x == y then '/' else y) filepath'
+
+--------------------------------------------------------------------------------
+-- Internal functions
+
+curDirNormalizedFP :: FilePath
+curDirNormalizedFP = '.' : [FilePath.pathSeparator]
+
+-- | Internal use for normalizing a directory.
+normalizeDir :: FilePath -> FilePath
+normalizeDir = FilePath.addTrailingPathSeparator . normalizeFilePath
+
+normalizeFilePath :: FilePath -> FilePath
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__) || MIN_VERSION_filepath(1,4,0)
+normalizeFilePath = FilePath.normalise
+#else
+normalizeFilePath = normalizeLeadingSeparators . FilePath.normalise
+    where
+        sep = FilePath.pathSeparator
+        normalizeLeadingSeparators (x1:x2:xs) | x1 == sep && x2 == sep
+            = normalizeLeadingSeparators (sep:xs)
+        normalizeLeadingSeparators x = x
+#endif

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
 module Path.Gen where
 
 import           Data.Functor
@@ -17,7 +18,7 @@ import           Data.GenValidity
 import           Test.QuickCheck
 
 
-instance Validity (Path Abs File) where
+instance Validity (Path 'Abs 'File) where
   isValid p@(Path fp)
     =  FilePath.isAbsolute fp
     && not (FilePath.hasTrailingPathSeparator fp)
@@ -25,7 +26,7 @@ instance Validity (Path Abs File) where
     && not (hasParentDir fp)
     && (parseAbsFile fp == Just p)
 
-instance Validity (Path Rel File) where
+instance Validity (Path 'Rel 'File) where
   isValid p@(Path fp)
     =  FilePath.isRelative fp
     && not (FilePath.hasTrailingPathSeparator fp)
@@ -34,7 +35,7 @@ instance Validity (Path Rel File) where
     && not (hasParentDir fp)
     && (parseRelFile fp == Just p)
 
-instance Validity (Path Abs Dir) where
+instance Validity (Path 'Abs 'Dir) where
   isValid p@(Path fp)
     =  FilePath.isAbsolute fp
     && FilePath.hasTrailingPathSeparator fp
@@ -42,7 +43,7 @@ instance Validity (Path Abs Dir) where
     && not (hasParentDir fp)
     && (parseAbsDir fp == Just p)
 
-instance Validity (Path Rel Dir) where
+instance Validity (Path 'Rel 'Dir) where
   isValid p@(Path fp)
     =  FilePath.isRelative fp
     && FilePath.hasTrailingPathSeparator fp
@@ -52,25 +53,25 @@ instance Validity (Path Rel Dir) where
     && not (hasParentDir fp)
     && (parseRelDir fp == Just p)
 
-instance GenUnchecked (Path Abs File) where
+instance GenUnchecked (Path 'Abs 'File) where
   genUnchecked = Path <$> genFilePath
 
-instance GenValid (Path Abs File)
+instance GenValid (Path 'Abs 'File)
 
-instance GenUnchecked (Path Rel File) where
+instance GenUnchecked (Path 'Rel 'File) where
   genUnchecked = Path <$> genFilePath
 
-instance GenValid (Path Rel File)
+instance GenValid (Path 'Rel 'File)
 
-instance GenUnchecked (Path Abs Dir) where
+instance GenUnchecked (Path 'Abs 'Dir) where
   genUnchecked = Path <$> genFilePath
 
-instance GenValid (Path Abs Dir)
+instance GenValid (Path 'Abs 'Dir)
 
-instance GenUnchecked (Path Rel Dir) where
+instance GenUnchecked (Path 'Rel 'Dir) where
   genUnchecked = Path <$> genFilePath
 
-instance GenValid (Path Rel Dir)
+instance GenValid (Path 'Rel 'Dir)
 
 -- | Generates 'FilePath's with a high occurence of @'.'@, @'\/'@ and
 -- @'\\'@ characters. The resulting 'FilePath's are not guaranteed to
@@ -81,16 +82,16 @@ genFilePath = listOf genPathyChar
 genPathyChar :: Gen Char
 genPathyChar = frequency [(2, arbitrary), (1, elements "./\\")]
 
-shrinkValidAbsFile :: Path Abs File -> [Path Abs File]
+shrinkValidAbsFile :: Path 'Abs 'File -> [Path 'Abs 'File]
 shrinkValidAbsFile = shrinkValidWith parseAbsFile
 
-shrinkValidAbsDir :: Path Abs Dir -> [Path Abs Dir]
+shrinkValidAbsDir :: Path 'Abs 'Dir -> [Path 'Abs 'Dir]
 shrinkValidAbsDir = shrinkValidWith parseAbsDir
 
-shrinkValidRelFile :: Path Rel File -> [Path Rel File]
+shrinkValidRelFile :: Path 'Rel 'File -> [Path 'Rel 'File]
 shrinkValidRelFile = shrinkValidWith parseRelFile
 
-shrinkValidRelDir :: Path Rel Dir -> [Path Rel Dir]
+shrinkValidRelDir :: Path 'Rel 'Dir -> [Path 'Rel 'Dir]
 shrinkValidRelDir = shrinkValidWith parseRelDir
 
 shrinkValidWith :: (FilePath -> Maybe (Path a b)) -> Path a b -> [Path a b]

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DataKinds #-}
 
 -- | Test suite.
 
@@ -266,11 +267,11 @@ parserTest parser input expected =
 aesonInstances :: Spec
 aesonInstances =
   do it "Decoding \"[\"/foo/bar\"]\" as a [Path Abs Dir] should succeed." $
-       eitherDecode (LBS.pack "[\"/foo/bar\"]") `shouldBe` Right [Path "/foo/bar/" :: Path Abs Dir]
+       eitherDecode (LBS.pack "[\"/foo/bar\"]") `shouldBe` Right [Path "/foo/bar/" :: Path 'Abs 'Dir]
      it "Decoding \"[\"/foo/bar\"]\" as a [Path Rel Dir] should fail." $
-       decode (LBS.pack "[\"/foo/bar\"]") `shouldBe` (Nothing :: Maybe [Path Rel Dir])
+       decode (LBS.pack "[\"/foo/bar\"]") `shouldBe` (Nothing :: Maybe [Path 'Rel 'Dir])
      it "Encoding \"[\"/foo/bar/mu.txt\"]\" should succeed." $
-       encode [Path "/foo/bar/mu.txt" :: Path Abs File] `shouldBe` (LBS.pack "[\"/foo/bar/mu.txt\"]")
+       encode [Path "/foo/bar/mu.txt" :: Path 'Abs 'File] `shouldBe` (LBS.pack "[\"/foo/bar/mu.txt\"]")
 
 -- | Test QuasiQuoters. Make sure they work the same as the $(mk*) constructors.
 quasiquotes :: Spec

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
 
 -- | Test suite.
 
@@ -49,19 +50,19 @@ operationFilename = do
                  filename (parent </> file) `shouldBe` filename file
 
      it "produces a valid path on when passed a valid absolute path" $ do
-        producesValidsOnValids (filename :: Path Abs File -> Path Rel File)
+        producesValidsOnValids (filename :: Path 'Abs 'File -> Path 'Rel 'File)
 
      it "produces a valid path on when passed a valid relative path" $ do
-        producesValidsOnValids (filename :: Path Rel File -> Path Rel File)
+        producesValidsOnValids (filename :: Path 'Rel 'File -> Path 'Rel 'File)
 
 -- | The 'parent' operation.
 operationParent :: Spec
 operationParent = do
      it "produces a valid path on when passed a valid file path" $ do
-        producesValidsOnValids (parent :: Path Abs File -> Path Abs Dir)
+        producesValidsOnValids (parent :: Path 'Abs 'File -> Path 'Abs 'Dir)
 
      it "produces a valid path on when passed a valid directory path" $ do
-        producesValidsOnValids (parent :: Path Abs Dir -> Path Abs Dir)
+        producesValidsOnValids (parent :: Path 'Abs 'Dir -> Path 'Abs 'Dir)
 
 -- | The 'isParentOf' operation.
 operationIsParentOf :: Spec
@@ -110,31 +111,31 @@ operationStripDir = do
                 stripDir parent (parent </> child) == Just child
 
      it "produces a valid path on when passed a valid absolute file paths" $ do
-        producesValidsOnValids2 (stripDir :: Path Abs Dir -> Path Abs File -> Maybe (Path Rel File))
+        producesValidsOnValids2 (stripDir :: Path 'Abs 'Dir -> Path 'Abs 'File -> Maybe (Path 'Rel 'File))
 
      it "produces a valid path on when passed a valid absolute directory paths" $ do
-        producesValidsOnValids2 (stripDir :: Path Abs Dir -> Path Abs Dir -> Maybe (Path Rel Dir))
+        producesValidsOnValids2 (stripDir :: Path 'Abs 'Dir -> Path 'Abs 'Dir -> Maybe (Path 'Rel 'Dir))
 
      it "produces a valid path on when passed a valid relative file paths" $ do
-        producesValidsOnValids2 (stripDir :: Path Rel Dir -> Path Rel File-> Maybe (Path Rel File))
+        producesValidsOnValids2 (stripDir :: Path 'Rel 'Dir -> Path 'Rel 'File-> Maybe (Path 'Rel 'File))
 
      it "produces a valid path on when passed a valid relative directory paths" $ do
-        producesValidsOnValids2 (stripDir :: Path Rel Dir -> Path Rel Dir -> Maybe (Path Rel Dir))
+        producesValidsOnValids2 (stripDir :: Path 'Rel 'Dir -> Path 'Rel 'Dir -> Maybe (Path 'Rel 'Dir))
 
 -- | The '</>' operation.
 operationAppend :: Spec
 operationAppend = do
      it "produces a valid path on when creating valid absolute file paths" $ do
-        producesValidsOnValids2 ((</>) :: Path Abs Dir -> Path Rel File -> Path Abs File)
+        producesValidsOnValids2 ((</>) :: Path 'Abs 'Dir -> Path 'Rel 'File -> Path 'Abs 'File)
 
      it "produces a valid path on when creating valid absolute directory paths" $ do
-        producesValidsOnValids2 ((</>) :: Path Abs Dir -> Path Rel Dir -> Path Abs Dir)
+        producesValidsOnValids2 ((</>) :: Path 'Abs 'Dir -> Path 'Rel 'Dir -> Path 'Abs 'Dir)
 
      it "produces a valid path on when creating valid relative file paths" $ do
-        producesValidsOnValids2 ((</>) :: Path Rel Dir -> Path Rel File -> Path Rel File)
+        producesValidsOnValids2 ((</>) :: Path 'Rel 'Dir -> Path 'Rel 'File -> Path 'Rel 'File)
 
      it "produces a valid path on when creating valid relative directory paths" $ do
-        producesValidsOnValids2 ((</>) :: Path Rel Dir -> Path Rel Dir -> Path Rel Dir)
+        producesValidsOnValids2 ((</>) :: Path 'Rel 'Dir -> Path 'Rel 'Dir -> Path 'Rel 'Dir)
 
 parserSpec :: (Show p, Validity p) => (FilePath -> Maybe p) -> Spec
 parserSpec parser =

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DataKinds #-}
 
 -- | Test suite.
 
@@ -260,11 +261,11 @@ parserTest parser input expected =
 aesonInstances :: Spec
 aesonInstances =
   do it "Decoding \"[\"C:\\\\foo\\\\bar\"]\" as a [Path Abs Dir] should succeed." $
-       eitherDecode (LBS.pack "[\"C:\\\\foo\\\\bar\"]") `shouldBe` Right [Path "C:\\foo\\bar\\" :: Path Abs Dir]
+       eitherDecode (LBS.pack "[\"C:\\\\foo\\\\bar\"]") `shouldBe` Right [Path "C:\\foo\\bar\\" :: Path 'Abs 'Dir]
      it "Decoding \"[\"C:\\foo\\bar\"]\" as a [Path Rel Dir] should fail." $
-       decode (LBS.pack "[\"C:\\foo\\bar\"]") `shouldBe` (Nothing :: Maybe [Path Rel Dir])
+       decode (LBS.pack "[\"C:\\foo\\bar\"]") `shouldBe` (Nothing :: Maybe [Path 'Rel 'Dir])
      it "Encoding \"[\"C:\\foo\\bar\\mu.txt\"]\" should succeed." $
-       encode [Path "C:\\foo\\bar\\mu.txt" :: Path Abs File] `shouldBe` (LBS.pack "[\"C:\\\\foo\\\\bar\\\\mu.txt\"]")
+       encode [Path "C:\\foo\\bar\\mu.txt" :: Path 'Abs 'File] `shouldBe` (LBS.pack "[\"C:\\\\foo\\\\bar\\\\mu.txt\"]")
 
 -- | Test QuasiQuoters. Make sure they work the same as the $(mk*) constructors.
 quasiquotes :: Spec


### PR DESCRIPTION
## Overview

This change makes it more clear at the API level what sorts of types
can be assigned to the Path data type. Furthermore, it makes error
messages more helpful when there's a kind mismatch.

Further, two new data types are introduced: PathRelativity and
FileType. These sum types make it clear that Abs | Rel are
mutually-exclusive, and similarly for File | Dir.

Tests and sources have been updated accordingly, including enabling
DataKinds and KindSignatures where needed.

## Detailed Summary

The changes are essentially, going from:

```haskell
data Rel deriving (Typeable)
data Abs deriving (Typeable)
data File deriving (Typeable)
data Dir deriving (Typeable)
newtype Path b t = Path FilePath
```

to

```haskell
{-# LANGUAGE DataKinds #-}
{-# LANGUAGE KindSignatures #-}

data PathRelativity = Abs | Rel deriving (Typeable)
data FileType = File | Dir deriving (Typeable)
newtype Path (b :: PathRelativity) (t :: FileType) = Path FilePath
```

## Final Notes

All tests pass on Linux. I've modified the Windows tests as need, but I haven't been able to test for myself.

The public API **should** be identical, even though some things needed to be moved around.

Let me know if y'all are interested in this PR.