### PR TITLE
Rename, export, document exceptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED:
 
+	* Deprecate PathParseException and rename it to PathException
 	* Allow 'parent' to work on relative paths as well
 	* Deprecate isParentOf and stripDir and rename them to isProperPrefixOf and
 	  stripProperPrefix respectively.


### PR DESCRIPTION
Also:

1) Rename PathParseException and one of its constructors
2) Export the constructors so that info about exceptions can be extracted.
3) Document which specific exception is thrown during each operation.

These are the remaining changes from #35 . These are breaking so should go before the next major version release.