### PR TITLE
Add stripFileExtensionFunction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 UNRELEASED:
         * Add 'Path.Posix' and 'Path.Windows' modules for manipulating
           Windows or Posix style paths independently of the current platform.
+	* Add 'stripFileExtension' function
 
 0.6.1:
 	* Add 'addFileExtension' function and its operator form: (<.>).

--- a/path.cabal
+++ b/path.cabal
@@ -29,6 +29,7 @@ library
                    , filepath   < 1.2.0.1  || >= 1.3
                    , hashable   >= 1.2     && < 1.3
                    , template-haskell
+                   , transformers >= 0.3
   default-language:  Haskell2010
 
 test-suite test

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -100,6 +100,10 @@ import           Language.Haskell.TH.Quote (QuasiQuoter(..))
 import           Path.Internal
 import qualified System.FilePath.PLATFORM_NAME as FilePath
 
+-- Setup code for doctest.
+-- $setup
+-- >>> :set -XTemplateHaskell
+
 --------------------------------------------------------------------------------
 -- Types
 

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -343,7 +343,7 @@ fileExtension = FilePath.takeExtension . toFilePath
 -- | Add extension to given file path. Throws if the
 -- resulting filename does not parse.
 --
--- >>> addFileExtension "txt $(mkRelFile "foo")
+-- >>> addFileExtension "txt" $(mkRelFile "foo")
 -- "foo.txt"
 -- >>> addFileExtension "symbols" $(mkRelFile "Data.List")
 -- "Data.List.symbols"

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -32,6 +32,7 @@ spec =
      describe "Operations: dirname" operationDirname
      describe "Operations: addFileExtension" operationAddFileExtension
      describe "Operations: setFileExtension" operationSetFileExtension
+     describe "Operations: stripExtension" operationStripExtension
      describe "Restrictions" restrictions
      describe "Aeson Instances" aesonInstances
      describe "QuasiQuotes" quasiquotes
@@ -218,6 +219,21 @@ operationSetFileExtension = do
   it "replaces extension if the input path already has one" $
     setFileExtension "txt" $(mkRelFile "foo.bar")
       `shouldReturn` $(mkRelFile "foo.txt")
+
+operationStripExtension :: Spec
+operationStripExtension = do
+  it "strips extension if there is one" $
+    stripFileExtension "txt" $(mkRelFile "foo.txt")
+      `shouldReturn` Just $(mkRelFile "foo")
+  it "strips extension specified with dot if there is one" $
+    stripFileExtension ".txt" $(mkRelFile "foo.txt")
+      `shouldReturn` Just $(mkRelFile "foo")
+  it "returns Nothing if extension doesn't match" $
+    stripFileExtension "quux" $(mkRelFile "foo.bar.bazz")
+      `shouldReturn` Nothing
+  it "throws exception if resulting file is empty" $
+    stripFileExtension ".bar.bazz" $(mkRelFile ".bar.bazz")
+      `shouldThrow` (== InvalidRelFile "")
 
 -- | Tests for the tokenizer.
 parseAbsDirSpec :: Spec

--- a/test/Posix.hs
+++ b/test/Posix.hs
@@ -12,7 +12,7 @@ import Control.Monad
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Maybe
-import Path
+import Path.Posix
 import Path.Internal
 import Test.Hspec
 

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -12,8 +12,8 @@ import Control.Monad
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Maybe
-import Path
 import Path.Internal
+import Path.Windows
 import Test.Hspec
 
 -- | Test suite (Windows version).


### PR DESCRIPTION
I noticed that `filepath` package has [stripExtension function](https://hackage.haskell.org/package/filepath-1.4.2/docs/System-FilePath-Posix.html#v:stripExtension), but `path` doesn't have anything like that. I have added it in this PR. I also took the liberty of unifying implementations of `addFileExtension`, 'removeFileExtension' and the new `stripFileExtension` functions. I have also submitted some tweaks to make package work with great `doctest` package and added tests for the `stripFileExtension` function.