### PR TITLE
Expose splitExtension operation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 UNRELEASED:
+	* BREAKING CHANGE: "fileExtension" now throws an exception if the file has no
+		extension. You can use the result as a "Maybe" in pure
+		code or handle the exception appropriately in any other monad.
 	* Old extension operations "addFileExtension" and "setFileExtension" have
 		been deprecated and replaced by "addExtension" and "replaceExtension"
-		respectively.
+		respectively with new behavior.
 		ADAPTING YOUR CODE TO THIS CHANGE:
 		* Code that sets an extension not starting with a "." e.g.  "foo", must
 		  be changed such that it starts with a "." i.e. ".foo".
@@ -18,8 +21,12 @@ UNRELEASED:
 		not including @.@ followed by zero or more @.@s in trailing position.
 		This change allows extension operations to be principled following
 		these laws:
-		* (fileExtension . fromJust . addExtension ext) f == ext
-		* replaceExtension (fileExtension f) f == Just f
+		* flip addExtension file >=> fileExtension == return
+		* (fileExtension >=> flip replaceExtension file) file == return file
+	* Add splitExtension operation such that:
+		* uncurry addExtension . swap >=> splitExtension == return
+		* splitExtension >=> uncurry addExtension . swap == return
+		* fileExtension == (fmap snd) . splitExtension@
 	* Add 'Path.Posix' and 'Path.Windows' modules for manipulating
 		Windows or Posix style paths independently of the current platform.
 	* Add 'Lift' instance for 'Path'.

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -56,10 +56,10 @@ module Path.PLATFORM_NAME
   ,parent
   ,filename
   ,dirname
-  ,fileExtension
   ,addExtension
-  ,replaceExtension
   ,splitExtension
+  ,fileExtension
+  ,replaceExtension
    -- * Parsing
   ,parseAbsDir
   ,parseRelDir
@@ -351,8 +351,29 @@ dirname (Path "") = Path ""
 dirname (Path l) | FilePath.isDrive l = Path ""
 dirname (Path l) = Path (last (FilePath.splitPath l))
 
--- | Split the given file path into a filename and an extension.  Throws
--- 'HasNoExtension' exception if the filename does not have an extension.
+-- | 'splitExtension' is the inverse of 'addExtension'. It splits the given
+-- file path into a valid filename and a valid extension.
+--
+-- >>> splitExtension $(mkRelFile "name.foo"     ) == Just ($(mkRelFile "name"    ), ".foo"  )
+-- >>> splitExtension $(mkRelFile "name.foo."    ) == Just ($(mkRelFile "name"    ), ".foo." )
+-- >>> splitExtension $(mkRelFile "name.foo.."   ) == Just ($(mkRelFile "name"    ), ".foo..")
+-- >>> splitExtension $(mkRelFile "name.bar.foo" ) == Just ($(mkRelFile "name.bar"), ".foo"  )
+-- >>> splitExtension $(mkRelFile ".name.foo"    ) == Just ($(mkRelFile ".name"   ), ".foo"  )
+-- >>> splitExtension $(mkRelFile "name..foo"    ) == Just ($(mkRelFile "name."   ), ".foo"  )
+-- >>> splitExtension $(mkRelFile "....foo"      ) == Just ($(mkRelFile "..."     ), ".foo"  )
+--
+-- Throws 'HasNoExtension' exception if the filename does not have an extension
+-- or in other words it cannot be split into a valid filename and a valid
+-- extension. The following cases throw an exception, please note that "." and
+-- ".." are not valid filenames:
+--
+-- >>> splitExtension $(mkRelFile "name"   )
+-- >>> splitExtension $(mkRelFile "name."  )
+-- >>> splitExtension $(mkRelFile "name.." )
+-- >>> splitExtension $(mkRelFile ".name"  )
+-- >>> splitExtension $(mkRelFile "..name" )
+-- >>> splitExtension $(mkRelFile "...name")
+--
 -- 'splitExtension' and 'addExtension' are inverses of each other, the
 -- following laws hold:
 --
@@ -364,10 +385,14 @@ dirname (Path l) = Path (last (FilePath.splitPath l))
 -- @since 0.7.0
 splitExtension :: MonadThrow m => Path b File -> m (Path b File, String)
 splitExtension (Path fpath) =
-    if nameDot == [] || ext == [] || all FilePath.isExtSeparator nameDot
+    if nameDot == [] || ext == []
     then throwM $ HasNoExtension fpath
-    else return (Path (drv ++ dir ++ (init nameDot)), FilePath.extSeparator : ext)
-
+    else let fname = init nameDot
+         in if fname == [] || fname == "." || fname == ".."
+            then throwM $ HasNoExtension fpath
+            else return ( Path (drv ++ dir ++ fname)
+                        , FilePath.extSeparator : ext
+                        )
     where
 
     -- trailing separators are ignored for the split and considered part of the
@@ -385,23 +410,12 @@ splitExtension (Path fpath) =
     (nameDot, ext) = splitLast FilePath.isExtSeparator file
 
 -- | Get extension from given file path. Throws 'HasNoExtension' exception if
--- the file does not have an extension.
+-- the file does not have an extension.  The following laws hold:
 --
--- >>> fileExtension $(mkRelFile "name.foo"     ) == ".foo"
--- >>> fileExtension $(mkRelFile "name.foo."    ) == ".foo."
--- >>> fileExtension $(mkRelFile "name.foo.."   ) == ".foo.."
--- >>> fileExtension $(mkRelFile "name.foo.bar" ) == ".bar"
--- >>> fileExtension $(mkRelFile ".name.foo"    ) == ".foo"
--- >>> fileExtension $(mkRelFile "name..foo"    ) == ".foo"
--- >>> fileExtension $(mkRelFile "name"         ) == ""
--- >>> fileExtension $(mkRelFile "name."        ) == ""
--- >>> fileExtension $(mkRelFile "name.."       ) == ""
--- >>> fileExtension $(mkRelFile ".name"        ) == ""
--- >>> fileExtension $(mkRelFile "..name"       ) == ""
---
--- The following law holds:
---
--- @fileExtension == (fmap snd) . splitExtension@
+-- @
+-- flip addExtension file >=> fileExtension == return
+-- fileExtension == (fmap snd) . splitExtension
+-- @
 --
 -- @since 0.5.11
 fileExtension :: MonadThrow m => Path b File -> m String
@@ -409,21 +423,26 @@ fileExtension = (fmap snd) . splitExtension
 
 -- | Add extension to given file path.
 --
--- >>> addExtension ".foo"   $(mkRelFile "name"     ) == "name.foo"
--- >>> addExtension ".foo."  $(mkRelFile "name"     ) == "name.foo."
--- >>> addExtension ".foo.." $(mkRelFile "name"     ) == "name.foo.."
--- >>> addExtension ".bar"   $(mkRelFile "name.foo" ) == "name.foo.bar"
+-- >>> addExtension ".foo"   $(mkRelFile "name"     ) == Just $(mkRelFile "name.foo"    )
+-- >>> addExtension ".foo."  $(mkRelFile "name"     ) == Just $(mkRelFile "name.foo."   )
+-- >>> addExtension ".foo.." $(mkRelFile "name"     ) == Just $(mkRelFile "name.foo.."  )
+-- >>> addExtension ".foo"   $(mkRelFile "name.bar" ) == Just $(mkRelFile "name.bar.foo")
+-- >>> addExtension ".foo"   $(mkRelFile ".name"    ) == Just $(mkRelFile ".name.foo"   )
+-- >>> addExtension ".foo"   $(mkRelFile "name."    ) == Just $(mkRelFile "name..foo"   )
+-- >>> addExtension ".foo"   $(mkRelFile "..."      ) == Just $(mkRelFile "....foo"     )
 --
 -- Throws an 'InvalidExtension' exception if the extension is not valid. A
 -- valid extension starts with a @.@ followed by one or more characters not
--- including @.@ followed by zero or more @.@s in trailing position. Moreover,
+-- including @.@ followed by zero or more @.@ in trailing position. Moreover,
 -- an extension must be a valid filename, notably it cannot include path
 -- separators. Particularly, @.foo.bar@ is an invalid extension, instead you
--- have to first set @.foo@ and then @.bar@ individually.
+-- have to first set @.foo@ and then @.bar@ individually. Some examples of
+-- invalid extensions are:
 --
--- The following law holds:
---
--- @flip addExtension file >=> fileExtension == return@
+-- >>> addExtension "foo"      $(mkRelFile "name")
+-- >>> addExtension "..foo"    $(mkRelFile "name")
+-- >>> addExtension ".foo.bar" $(mkRelFile "name")
+-- >>> addExtension ".foo/bar" $(mkRelFile "name")
 --
 -- @since 0.7.0
 addExtension :: MonadThrow m

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -419,7 +419,7 @@ splitExtension (Path fpath) =
 --
 -- @since 0.5.11
 fileExtension :: MonadThrow m => Path b File -> m String
-fileExtension = (fmap snd) . splitExtension
+fileExtension = (liftM snd) . splitExtension
 
 -- | Add extension to given file path.
 --

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -18,7 +18,7 @@ validExtensionsSpec ext file fext = do
         addExtension ext file `shouldReturn` fext
 
     it ("fileExtension " ++ fx ++ " == " ++ ext) $
-        fileExtension fext `shouldBe` ext
+        fileExtension fext `shouldReturn` ext
 
     it ("replaceExtension " ++ show ext ++ " " ++ fx ++ " == " ++ fx) $
         replaceExtension ext fext `shouldReturn` fext

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -67,6 +67,7 @@ extensionOperations rootDrive = do
         , "..name"
         , "name.name"
         , "name..name"
+        , "..."
         ]
     dirnames = filenames ++ ["."]
     invalidExtensions =
@@ -82,5 +83,5 @@ extensionOperations rootDrive = do
         , "..foo"
         , "...foo"
         , ".foo.bar"
-        , ".evil" ++ [pathSeparator] ++ "foo"
+        , ".foo" ++ [pathSeparator] ++ "bar"
         ]

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -160,6 +160,18 @@ extensionsSpec = do
                 Nothing -> True
                 Just (f, ext) -> toFilePath f ++ ext == toFilePath file
 
+     it "splitExtension generates a valid filename and valid extension" $
+         forAllShrink genValid shrinkValidRelFile $ \file ->
+            case splitExtension file of
+                Nothing -> True
+                Just (f, ext) -> case parseRelFile ext of
+                    Nothing -> False
+                    Just _ -> case parseRelFile (toFilePath f) of
+                        Nothing -> case parseAbsFile (toFilePath f) of
+                            Nothing -> False
+                            Just _ -> True
+                        Just _ -> True
+
      it "splitExtension >=> uncurry addExtension . swap == return" $
          forAllShrink genValid shrinkValidRelFile $ \file ->
             case splitExtension file of

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -154,17 +154,41 @@ extensionsSpec = do
                 (toFilePath . fromJust . addExtension ext) file
                  `shouldBe` toFilePath file ++ ext
 
-     it "(fileExtension . fromJust . addExtension ext) f == ext" $
+     it "splitExtension output joins to result in the original file" $
+         forAllShrink genValid shrinkValidRelFile $ \file ->
+            case splitExtension file of
+                Nothing -> True
+                Just (f, ext) -> toFilePath f ++ ext == toFilePath file
+
+     it "splitExtension >=> uncurry addExtension . swap == return" $
+         forAllShrink genValid shrinkValidRelFile $ \file ->
+            case splitExtension file of
+                Nothing -> True
+                Just (f, ext) -> addExtension ext f == Just file
+
+     it "uncurry addExtension . swap >=> splitExtension == return" $
+         forAllShrink genValid shrinkValidRelFile $ \file ->
+             forAllShrink genValid shrinkValidExtension $ \(Extension ext) ->
+                (addExtension ext file >>= splitExtension)
+                `shouldReturn` (file, ext)
+
+     it "fileExtension == (fmap snd) . splitExtension" $
+         forAllShrink genValid shrinkValidRelFile $ \file ->
+            case splitExtension file of
+                Nothing -> True
+                Just (_, ext) -> fileExtension file == Just ext
+
+     it "flip addExtension file >=> fileExtension == return" $
          forAllShrink genValid shrinkValidRelFile $ \file ->
              forAllShrink genValid shrinkValidExtension $ \(Extension ext) ->
                  (fileExtension . fromJust . addExtension ext) file
-                 `shouldBe` ext
+                 `shouldReturn` ext
 
-     it "(flip replaceExtension f . fileExtension) f) == f" $
+     it "(fileExtension >=> flip replaceExtension file) file == return file" $
          forAllShrink genValid shrinkValidRelFile $ \file ->
             case fileExtension file of
-                "" -> True
-                ext -> replaceExtension ext file == Just file
+                Nothing -> True
+                Just ext -> replaceExtension ext file == Just file
 
     where
         addExtGensValidFile p =


### PR DESCRIPTION
1) Breaking - Change the return type of `fileExtension` to throw an exception when there is no extension

2) Now all the extension operations can be expressed elegantly in terms of simple laws, all of them verified by property tests. `addExtension` and `splitExtension` are the basic operations and the rest are just convenient and trivial applications of these two. `addExtension` and `splitExtension` are lawful inverses of each other with this change.