### PR TITLE
Fix replaceExtension or just drop it?

### DIFF
--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -542,7 +542,8 @@ replaceExtension :: MonadThrow m
   => String            -- ^ Extension to set
   -> Path b File       -- ^ Old file name
   -> m (Path b File)   -- ^ New file name with the desired extension
-replaceExtension ext path = splitExtension path >>= addExtension ext . fst
+replaceExtension ext path =
+    addExtension ext (maybe path fst $ splitExtension path)
 
 -- | Replace\/add extension to given file path. Throws if the
 -- resulting filename does not parse.


### PR DESCRIPTION
I broke this in my previous change, the tests did not catch this, need to add tests to catch the broken case. But before I do that, let's first resolve this comment from my previous PR:

Another point that I am considering is that since we are re-introducing `replaceExtension` why not just drop this API. The is a bit awkward to explain (or non-intuitive) API since it can either REPLACE an extension or SET an extension and I am not sure how much useful it is in practice to warrant a place in the library. Anyway, now it is trivial to implement using other primitives if anyone really needs something like this, it is just:

```
addExtension ".ext" (maybe f fst $ splitExtension f)
```