### PR TITLE
Update LTS to 12.0

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -75,12 +75,12 @@ test-suite validity-test
                    , base       >= 4.7 && < 5
                    , bytestring
                    , filepath   < 1.2.0.1  || >= 1.3
-                   , genvalidity >= 0.3 && < 0.4
-                   , genvalidity-property >= 0.0 && < 0.1
+                   , genvalidity
+                   , genvalidity-property
                    , hspec      >= 2.0     && < 3
                    , mtl        >= 2.0     && < 3
                    , path
-                   , validity   >= 0.3.1.1 && < 0.4
+                   , validity
   default-language:  Haskell2010
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,1 @@
-extra-deps:
-- genvalidity-0.3.2.0
-- genvalidity-property-0.0.0.0
-- validity-0.3.3.0
-resolver: lts-8.3
+resolver: lts-12.0

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -19,66 +19,67 @@ import           Test.QuickCheck
 
 
 instance Validity (Path Abs File) where
-  isValid p@(Path fp)
-    =  FilePath.isAbsolute fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseAbsFile fp == Just p)
+  validate p@(Path fp) =  check (FilePath.isAbsolute fp)                     "Path is absolute."
+                       <> check (not (FilePath.hasTrailingPathSeparator fp)) "Path does not have trailing seperator."
+                       <> check (FilePath.isValid fp)                        "Path is valid."
+                       <> check (not (hasParentDir fp))                      "Path does not have parent dir."
+                       <> check ((parseAbsFile fp == Just p))                "Path parses."
 
 instance Validity (Path Rel File) where
-  isValid p@(Path fp)
-    =  FilePath.isRelative fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-    && FilePath.isValid fp
-    && fp /= "."
-    && not (hasParentDir fp)
-    && (parseRelFile fp == Just p)
+  validate p@(Path fp) =  check (FilePath.isRelative fp)                     "Path is relative."
+                       <> check (not (FilePath.hasTrailingPathSeparator fp)) "Path does not have trailing seperator."
+                       <> check (FilePath.isValid fp)                        "Path is valid."
+                       <> check (fp /= ".")                                  "Path is not '.' ."
+                       <> check (not (hasParentDir fp))                      "Path does not have parent dir."
+                       <> check ((parseRelFile fp == Just p))                "Path parses."
 
 instance Validity (Path Abs Dir) where
-  isValid p@(Path fp)
-    =  FilePath.isAbsolute fp
-    && FilePath.hasTrailingPathSeparator fp
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseAbsDir fp == Just p)
-
+  validate p@(Path fp) =  check (FilePath.isAbsolute fp)               "Path is absolute."
+                       <> check (FilePath.hasTrailingPathSeparator fp) "Path has trailing seperator."
+                       <> check (FilePath.isValid fp)                  "Path is valid."
+                       <> check (not (hasParentDir fp))                 "Path does not have parent dir."
+                       <> check ((parseAbsDir fp == Just p))           "Path parses."
+                         
 instance Validity (Path Rel Dir) where
-  isValid p =
-    FilePath.isRelative fp
-    && FilePath.hasTrailingPathSeparator fp
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseRelDir fp == Just p)
+  validate p =  check (FilePath.isRelative fp)               "Path is relative."
+             <> check (FilePath.hasTrailingPathSeparator fp) "Path has trailing seperator"
+             <> check (FilePath.isValid fp)                  "Path is valid."
+             <> check (not (hasParentDir fp))                "Path does not have parent dir."
+             <> check ((parseRelDir fp == Just p))           "Path parses."
     where fp = toFilePath p
 
 instance GenUnchecked (Path Abs File) where
   genUnchecked = Path <$> genFilePath
+  shrinkUnchecked (Path p) = Path <$> shrink p
 
 instance GenValid (Path Abs File)
 
 instance GenUnchecked (Path Rel File) where
   genUnchecked = Path <$> genFilePath
+  shrinkUnchecked (Path p) = Path <$> shrink p
 
 instance GenValid (Path Rel File)
 
 instance GenUnchecked (Path Abs Dir) where
   genUnchecked = Path <$> genFilePath
+  shrinkUnchecked (Path p) = Path <$> shrink p
 
 instance GenValid (Path Abs Dir)
 
 instance GenUnchecked (Path Rel Dir) where
   genUnchecked = Path <$> genFilePath
+  shrinkUnchecked (Path p) = Path <$> shrink p
 
 instance GenValid (Path Rel Dir)
 
 data Extension = Extension String deriving Show
 
 instance Validity Extension where
-  isValid (Extension ext) = isJust $ addExtension ext $(mkRelFile "x")
+  validate (Extension ext) = check (isJust $ addExtension ext $(mkRelFile "x")) "Extension is valid."
 
 instance GenUnchecked Extension where
   genUnchecked = Extension <$> genFilePath
+  shrinkUnchecked (Extension ext) = Extension <$> shrink ext
 
 instance GenValid Extension
 

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -214,4 +214,4 @@ extensionsSpec = do
 parserSpec :: (Show p, Validity p) => (FilePath -> Maybe p) -> Spec
 parserSpec parser =
      it "Produces valid paths when it succeeds" $
-       validIfSucceedsOnGen parser genFilePath
+       validIfSucceedsOnGen parser genFilePath (const [])


### PR DESCRIPTION
Updated LTS to 12.0. In order to do this we needed to take care of
validity, which has a new API in 12.0. As a result, tests are updated.
Changes are almost 100% superficial, with the only semantical change
being added shrinking for unchecked generators, although they are
1) Never used in the current code.
2) Just wrappers around String shrinking.

As a result we no longer have validity as an external dependency, as it
is in LTS 12.0.