### PR TITLE
Fixed FIXMEs in Windows tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,10 @@ UNRELEASED:
 	* Add 'Path.Posix' and 'Path.Windows' modules for manipulating
 		Windows or Posix style paths independently of the current platform.
 	* Add 'Lift' instance for 'Path'.
+	* `Path.Windows` normalizes path separators throughout path,
+		including immediately following drive letter.
+	* `Path.Windows` handles UNC (`\\host\share\`) and Unicode (`\\?\C:\`) path
+		without breaking the double-separator prefix.
 
 0.6.1:
 	* Add 'addFileExtension' function and its operator form: (<.>).

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -740,7 +740,8 @@ normalizeDir =
       normalizeRelDir p | p == relRootFP = ""
       normalizeRelDir p = p
 
--- | Replaces consecutive path seps with single sep.
+-- | Replaces consecutive path seps with single sep
+-- | and replaces alt sep with standard sep.
 normalizeAllSeps :: FilePath -> FilePath
 normalizeAllSeps = foldr norm []
   where
@@ -751,21 +752,21 @@ normalizeAllSeps = foldr norm []
         FilePath.isPathSeparator ch = FilePath.pathSeparator:path
       norm ch path = ch:path
 
--- | Replaces consecutive path seps with single sep except at the beginning of a path.
+-- | Normalizes seps except at the beginning of path.
 normalizeSepsExceptLeading :: FilePath -> FilePath
 normalizeSepsExceptLeading path = normLeadingSeps ++ normalizeAllSeps rest
   where leadingSeps = takeWhile FilePath.isPathSeparator path
         normLeadingSeps = replicate (min 2 (length leadingSeps)) FilePath.pathSeparator
         rest = dropWhile FilePath.isPathSeparator path
 
--- | Replaces consecutive path seps with single sep at the beginning of a path.
+-- | Normalizes seps only at the beginning of a path.
 normalizeLeadingSeps :: FilePath -> FilePath
 normalizeLeadingSeps (p0:p1:ps) |
   FilePath.isPathSeparator p0 && FilePath.isPathSeparator p1 =
     normalizeLeadingSeps (FilePath.pathSeparator:ps)
 normalizeLeadingSeps path = path
 
--- | Replaces consecutive path seps at the end of a path.
+-- | Normalizes seps only at the end of a path.
 normalizeTrailingSeps :: FilePath -> FilePath
 normalizeTrailingSeps = reverse . normalizeLeadingSeps . reverse
 

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -63,19 +63,19 @@ operationDirname =
   do it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (absolute)"
         (dirnamesShouldBeEqual
           ($(mkAbsDir "C:\\chris\\") </> $(mkRelDir "bar"))
-           $(mkRelDir "bar"))
+          $(mkRelDir "bar"))
      it "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (relative)"
         (dirnamesShouldBeEqual
           ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar"))
-           $(mkRelDir "bar"))
+          $(mkRelDir "bar"))
      it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (UNC)"
         (dirnamesShouldBeEqual
           ($(mkAbsDir "\\\\home\\chris\\") </> $(mkRelDir "bar"))
-           $(mkRelDir "bar"))
+          $(mkRelDir "bar"))
      it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (Unicode)"
         (dirnamesShouldBeEqual
           ($(mkAbsDir "\\\\?\\C:\\home\\chris\\") </> $(mkRelDir "bar"))
-           $(mkRelDir "bar"))
+          $(mkRelDir "bar"))
      it "dirname $(mkRelDir .) == $(mkRelDir .)"
         (dirnamesShouldBeEqual
           $(mkRelDir ".")
@@ -90,28 +90,26 @@ operationFilename =
   do it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (absolute)"
         (filenamesShouldBeEqual
           ($(mkAbsDir "C:\\chris\\") </> $(mkRelFile "bar.txt"))
-           $(mkRelFile "bar.txt"))
+          $(mkRelFile "bar.txt"))
      it "filename ($(mkRelDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (relative)"
         (filenamesShouldBeEqual
           ($(mkRelDir "home\\chris\\") </> $(mkRelFile "bar.txt"))
-           $(mkRelFile "bar.txt"))
+          $(mkRelFile "bar.txt"))
      it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (UNC)"
         (filenamesShouldBeEqual
           ($(mkAbsDir "\\\\host\\share\\chris\\") </> $(mkRelFile "bar.txt"))
-           $(mkRelFile "bar.txt"))
+          $(mkRelFile "bar.txt"))
      it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (Unicode)"
         (filenamesShouldBeEqual
           ($(mkAbsDir "\\\\?\\C:\\home\\chris\\") </> $(mkRelFile "bar.txt"))
-           $(mkRelFile "bar.txt"))
+          $(mkRelFile "bar.txt"))
   where filenamesShouldBeEqual = (==) `on` filename
 
 -- | The 'parent' operation.
 operationParent :: Spec
 operationParent =
   do it "parent (parent </> child) == parent"
-        (parent ($(mkAbsDir "C:\\foo") </>
-                    $(mkRelDir "bar")) ==
-         $(mkAbsDir "C:\\foo"))
+        (parent ($(mkAbsDir "C:\\foo") </> $(mkRelDir "bar")) == $(mkAbsDir "C:\\foo"))
      it "parent \"C:\\\" == \"C:\\\""
         (parent $(mkAbsDir "C:\\") == $(mkAbsDir "C:\\"))
      it "parent \"C:\\x\" == \"C:\\\""
@@ -126,19 +124,19 @@ operationIsProperPrefixOf :: Spec
 operationIsProperPrefixOf =
   do it "isProperPrefixOf parent (parent </> child) (absolute)"
         (isProperPrefixOf
-           $(mkAbsDir "C:\\\\\\bar\\")
+          $(mkAbsDir "C:\\\\\\bar\\")
           ($(mkAbsDir "C:\\\\\\bar\\") </> $(mkRelFile "bar\\foo.txt")))
      it "isProperPrefixOf parent (parent </> child) (relative)"
         (isProperPrefixOf
-           $(mkRelDir "bar\\")
+          $(mkRelDir "bar\\")
           ($(mkRelDir "bar\\") </> $(mkRelFile "bob\\foo.txt")))
      it "isProperPrefixOf parent (parent </> child) (UNC)"
         (isProperPrefixOf
-           $(mkAbsDir "\\\\host\\share\\")
+          $(mkAbsDir "\\\\host\\share\\")
           ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "bob\\foo.txt")))
      it "isProperPrefixOf parent (parent </> child) (Unicode)"
         (isProperPrefixOf
-           $(mkAbsDir "\\\\?\\C:\\folder\\")
+          $(mkAbsDir "\\\\?\\C:\\folder\\")
           ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "bob\\foo.txt")))
      it "not (x `isProperPrefixOf` x)"
         (not (isProperPrefixOf $(mkRelDir "x") $(mkRelDir "x")))
@@ -151,23 +149,23 @@ operationStripProperPrefix =
   do it "stripProperPrefix parent (parent </> child) = child (absolute)"
         (remainingPathShouldBe
           $(mkAbsDir "C:\\\\\\bar\\")
-         ($(mkAbsDir "C:\\\\\\bar\\") </> $(mkRelFile "bar\\foo.txt"))
-         (Just $(mkRelFile "bar\\foo.txt")))
+          ($(mkAbsDir "C:\\\\\\bar\\") </> $(mkRelFile "bar\\foo.txt"))
+          (Just $(mkRelFile "bar\\foo.txt")))
      it "stripProperPrefix parent (parent </> child) = child (relative)"
         (remainingPathShouldBe
           $(mkRelDir "bar\\")
-         ($(mkRelDir "bar\\") </> $(mkRelFile "bob\\foo.txt"))
-         (Just $(mkRelFile "bob\\foo.txt")))
+          ($(mkRelDir "bar\\") </> $(mkRelFile "bob\\foo.txt"))
+          (Just $(mkRelFile "bob\\foo.txt")))
      it "stripProperPrefix parent (parent </> child) = child (UNC)"
         (remainingPathShouldBe
           $(mkAbsDir "\\\\host\\share\\")
-         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "bob\\foo.txt"))
-         (Just $(mkRelFile "bob\\foo.txt")))
+          ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "bob\\foo.txt"))
+          (Just $(mkRelFile "bob\\foo.txt")))
      it "stripProperPrefix parent (parent </> child) = child (Unicode)"
         (remainingPathShouldBe
           $(mkAbsDir "\\\\?\\C:\\folder\\")
-         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "bob\\foo.txt"))
-         (Just $(mkRelFile "bob\\foo.txt")))
+          ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "bob\\foo.txt"))
+          (Just $(mkRelFile "bob\\foo.txt")))
      it "stripProperPrefix parent parent = _|_"
         (remainingPathShouldBe
           $(mkAbsDir "C:\\home\\chris\\foo")
@@ -181,47 +179,47 @@ operationAppend :: Spec
 operationAppend =
   do it "AbsDir + RelDir = AbsDir"
         (shouldBe
-         ($(mkAbsDir "C:\\home\\") </> $(mkRelDir "chris"))
+          ($(mkAbsDir "C:\\home\\") </> $(mkRelDir "chris"))
           $(mkAbsDir "C:\\home\\chris\\"))
      it "AbsDir + RelFile = AbsFile"
         (shouldBe
-         ($(mkAbsDir "C:\\home\\") </> $(mkRelFile "chris\\test.txt"))
+          ($(mkAbsDir "C:\\home\\") </> $(mkRelFile "chris\\test.txt"))
           $(mkAbsFile "C:\\home\\chris\\test.txt"))
      it "RelDir + RelDir = RelDir"
         (shouldBe
-         ($(mkRelDir "home\\") </> $(mkRelDir "chris"))
+          ($(mkRelDir "home\\") </> $(mkRelDir "chris"))
           $(mkRelDir "home\\chris"))
      it ". + . = ."
         (shouldBe
-         ($(mkRelDir ".\\") </> $(mkRelDir "."))
+          ($(mkRelDir ".\\") </> $(mkRelDir "."))
           $(mkRelDir "."))
      it ". + x = x"
         (shouldBe
-         ($(mkRelDir ".") </> $(mkRelDir "x"))
+          ($(mkRelDir ".") </> $(mkRelDir "x"))
           $(mkRelDir "x"))
      it "x + . = x"
         (shouldBe
-         ($(mkRelDir "x") </> $(mkRelDir ".\\"))
+          ($(mkRelDir "x") </> $(mkRelDir ".\\"))
           $(mkRelDir "x"))
      it "RelDir + RelFile = RelFile"
         (shouldBe
-         ($(mkRelDir "home\\") </> $(mkRelFile "chris\\test.txt"))
+          ($(mkRelDir "home\\") </> $(mkRelFile "chris\\test.txt"))
           $(mkRelFile "home\\chris\\test.txt"))
      it "AbsDir(UNC) + RelDir = AbsDir(UNC)"
         (shouldBe
-         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelDir "folder\\"))
+          ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelDir "folder\\"))
           $(mkAbsDir "\\\\host\\share\\folder\\"))
      it "AbsDir(UNC) + RelFile = AbsFile(UNC)"
         (shouldBe
-         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "folder\\file.txt"))
+          ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "folder\\file.txt"))
           $(mkAbsFile "\\\\host\\share\\folder\\file.txt"))
      it "AbsDir(Unicode) + RelDir = AbsDir(Unicode)"
         (shouldBe
-         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelDir "another\\"))
+          ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelDir "another\\"))
           $(mkAbsDir "\\\\?\\C:\\folder\\another\\"))
      it "AbsDir(Unicode) + RelFile = AbsFile(Unicode)"
         (shouldBe
-         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "file.txt"))
+          ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "file.txt"))
           $(mkAbsFile "\\\\?\\C:\\folder\\file.txt"))
 
 operationToFilePath :: Spec

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -184,11 +184,12 @@ parseAbsDirSpec =
   do failing ""
      failing ".\\"
      failing "foo.txt"
+     failing "C:"
      succeeding "C:\\" (Path "C:\\")
-     succeeding "C:\\\\" (Path "C:\\\\")
-     -- succeeding "C:\\\\\\foo\\\\bar\\\\mu\\" (Path "C:\\foo\\bar\\mu\\") FIXME
-     -- succeeding "C:\\\\\\foo\\\\bar\\\\mu" (Path "C:\\foo\\bar\\mu\\") FIXME
-     -- succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu" (Path "C:\\foo\\bar\\mu\\") FIXME
+     succeeding "C:\\\\" (Path "C:\\")
+     succeeding "C:\\\\\\foo\\\\bar\\\\mu\\" (Path "C:\\foo\\bar\\mu\\")
+     succeeding "C:\\\\\\foo\\\\bar\\\\mu" (Path "C:\\foo\\bar\\mu\\")
+     succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu" (Path "C:\\foo\\bar\\mu\\")
 
   where failing x = parserTest parseAbsDir x Nothing
         succeeding x with = parserTest parseAbsDir x (Just with)
@@ -197,16 +198,15 @@ parseAbsDirSpec =
 parseRelDirSpec :: Spec
 parseRelDirSpec =
   do failing ""
-     -- failing "/" FIXME
-     -- failing "//" FIXME
-     -- succeeding "~/" (Path "~/") -- https://github.com/chrisdone/path/issues/19
-     -- failing "\\" FIXME
-     succeeding ".\\" (Path "")
-     succeeding ".\\.\\" (Path "")
+     failing "/"
+     failing "//"
+     failing "\\"
      failing "\\\\"
      failing "\\\\\\foo\\\\bar\\\\mu\\"
      failing "\\\\\\foo\\\\bar\\\\\\\\mu"
      failing "\\\\\\foo\\\\bar\\.\\\\mu"
+     succeeding ".\\" (Path "")
+     succeeding ".\\.\\" (Path "")
      succeeding "..." (Path "...\\")
      succeeding "foo.bak" (Path "foo.bak\\")
      succeeding ".\\foo" (Path "foo\\")
@@ -231,13 +231,13 @@ parseAbsFileSpec =
      failing "\\"
      failing "\\\\"
      failing "\\\\\\foo\\\\bar\\\\mu\\"
-     -- succeeding "\\..." (Path "\\...") FIXME
-     -- succeeding "\\foo.txt" (Path "\\foo.txt") FIXME
-     -- succeeding "C:\\\\\\foo\\\\bar\\\\\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt") FIXME
-     -- succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt") FIXME
+     failing "\\..."
+     failing "\\foo.txt"
+     succeeding "C:\\\\\\foo\\\\bar\\\\\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt")
+     succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt")
 
   where failing x = parserTest parseAbsFile x Nothing
-        -- succeeding x with = parserTest parseAbsFile x (Just with)
+        succeeding x with = parserTest parseAbsFile x (Just with)
 
 -- | Tests for the tokenizer.
 parseRelFileSpec :: Spec

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -11,6 +11,7 @@ import Control.Applicative
 import Control.Monad
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.Function (on)
 import Data.Maybe
 import Path.Windows
 import Path.Internal
@@ -58,35 +59,51 @@ restrictions =
 
 -- | The 'dirname' operation.
 operationDirname :: Spec
-operationDirname = do
-  it
-    "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkAbsDir "C:\\chris\\") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
-  it
-    "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (unit test)"
-    (dirname ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar")) ==
-     dirname $(mkRelDir "bar"))
-  it
-    "dirname $(mkRelDir .) == $(mkRelDir .)"
-    (dirname $(mkRelDir ".") == $(mkRelDir "."))
-  it
-    "dirname C:\\ must be a Rel path"
-    ((parseAbsDir $ show $ dirname (fromJust (parseAbsDir "C:\\"))
-     :: Maybe (Path Abs Dir)) == Nothing)
+operationDirname =
+  do it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (absolute)"
+        (dirnamesShouldBeEqual
+          ($(mkAbsDir "C:\\chris\\") </> $(mkRelDir "bar"))
+           $(mkRelDir "bar"))
+     it "dirname ($(mkRelDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (relative)"
+        (dirnamesShouldBeEqual
+          ($(mkRelDir "home\\chris\\") </> $(mkRelDir "bar"))
+           $(mkRelDir "bar"))
+     it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (UNC)"
+        (dirnamesShouldBeEqual
+          ($(mkAbsDir "\\\\home\\chris\\") </> $(mkRelDir "bar"))
+           $(mkRelDir "bar"))
+     it "dirname ($(mkAbsDir parent) </> $(mkRelFile dirname)) == dirname $(mkRelFile dirname) (Unicode)"
+        (dirnamesShouldBeEqual
+          ($(mkAbsDir "\\\\?\\C:\\home\\chris\\") </> $(mkRelDir "bar"))
+           $(mkRelDir "bar"))
+     it "dirname $(mkRelDir .) == $(mkRelDir .)"
+        (dirnamesShouldBeEqual
+          $(mkRelDir ".")
+          $(mkRelDir "."))
+     it "dirname C:\\ must be a Rel path"
+        ((parseAbsDir $ show $ dirname (fromJust (parseAbsDir "C:\\")) :: Maybe (Path Abs Dir)) == Nothing)
+  where dirnamesShouldBeEqual = (==) `on` dirname
 
 -- | The 'filename' operation.
 operationFilename :: Spec
 operationFilename =
-  do it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (unit test)"
-          (filename ($(mkAbsDir "C:\\chris\\") </>
-                             $(mkRelFile "bar.txt")) ==
-                                      filename $(mkRelFile "bar.txt"))
-
-     it "filename ($(mkRelDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (unit test)"
-             (filename ($(mkRelDir "home\\chris\\") </>
-                                $(mkRelFile "bar.txt")) ==
-                                         filename $(mkRelFile "bar.txt"))
+  do it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (absolute)"
+        (filenamesShouldBeEqual
+          ($(mkAbsDir "C:\\chris\\") </> $(mkRelFile "bar.txt"))
+           $(mkRelFile "bar.txt"))
+     it "filename ($(mkRelDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (relative)"
+        (filenamesShouldBeEqual
+          ($(mkRelDir "home\\chris\\") </> $(mkRelFile "bar.txt"))
+           $(mkRelFile "bar.txt"))
+     it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (UNC)"
+        (filenamesShouldBeEqual
+          ($(mkAbsDir "\\\\host\\share\\chris\\") </> $(mkRelFile "bar.txt"))
+           $(mkRelFile "bar.txt"))
+     it "filename ($(mkAbsDir parent) </> $(mkRelFile filename)) == filename $(mkRelFile filename) (Unicode)"
+        (filenamesShouldBeEqual
+          ($(mkAbsDir "\\\\?\\C:\\home\\chris\\") </> $(mkRelFile "bar.txt"))
+           $(mkRelFile "bar.txt"))
+  where filenamesShouldBeEqual = (==) `on` filename
 
 -- | The 'parent' operation.
 operationParent :: Spec
@@ -110,66 +127,102 @@ operationIsProperPrefixOf =
   do it "isProperPrefixOf parent (parent </> child) (absolute)"
         (isProperPrefixOf
            $(mkAbsDir "C:\\\\\\bar\\")
-           ($(mkAbsDir "C:\\\\\\bar\\") </>
-            $(mkRelFile "bar\\foo.txt")))
-
+          ($(mkAbsDir "C:\\\\\\bar\\") </> $(mkRelFile "bar\\foo.txt")))
      it "isProperPrefixOf parent (parent </> child) (relative)"
         (isProperPrefixOf
            $(mkRelDir "bar\\")
-           ($(mkRelDir "bar\\") </>
-            $(mkRelFile "bob\\foo.txt")))
-
+          ($(mkRelDir "bar\\") </> $(mkRelFile "bob\\foo.txt")))
+     it "isProperPrefixOf parent (parent </> child) (UNC)"
+        (isProperPrefixOf
+           $(mkAbsDir "\\\\host\\share\\")
+          ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "bob\\foo.txt")))
+     it "isProperPrefixOf parent (parent </> child) (Unicode)"
+        (isProperPrefixOf
+           $(mkAbsDir "\\\\?\\C:\\folder\\")
+          ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "bob\\foo.txt")))
      it "not (x `isProperPrefixOf` x)"
         (not (isProperPrefixOf $(mkRelDir "x") $(mkRelDir "x")))
-
      it "not (\\ `isProperPrefixOf` \\)"
         (not (isProperPrefixOf $(mkAbsDir "C:\\") $(mkAbsDir "C:\\")))
 
 -- | The 'stripProperPrefix' operation.
 operationStripProperPrefix :: Spec
 operationStripProperPrefix =
-  do it "stripProperPrefix parent (parent </> child) = child (unit test)"
-        (stripProperPrefix $(mkAbsDir "C:\\\\\\bar\\")
-                  ($(mkAbsDir "C:\\\\\\bar\\") </>
-                   $(mkRelFile "bar\\foo.txt")) ==
-         Just $(mkRelFile "bar\\foo.txt"))
-
-     it "stripProperPrefix parent (parent </> child) = child (unit test)"
-        (stripProperPrefix $(mkRelDir "bar\\")
-                  ($(mkRelDir "bar\\") </>
-                   $(mkRelFile "bob\\foo.txt")) ==
-         Just $(mkRelFile "bob\\foo.txt"))
-
+  do it "stripProperPrefix parent (parent </> child) = child (absolute)"
+        (remainingPathShouldBe
+          $(mkAbsDir "C:\\\\\\bar\\")
+         ($(mkAbsDir "C:\\\\\\bar\\") </> $(mkRelFile "bar\\foo.txt"))
+         (Just $(mkRelFile "bar\\foo.txt")))
+     it "stripProperPrefix parent (parent </> child) = child (relative)"
+        (remainingPathShouldBe
+          $(mkRelDir "bar\\")
+         ($(mkRelDir "bar\\") </> $(mkRelFile "bob\\foo.txt"))
+         (Just $(mkRelFile "bob\\foo.txt")))
+     it "stripProperPrefix parent (parent </> child) = child (UNC)"
+        (remainingPathShouldBe
+          $(mkAbsDir "\\\\host\\share\\")
+         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "bob\\foo.txt"))
+         (Just $(mkRelFile "bob\\foo.txt")))
+     it "stripProperPrefix parent (parent </> child) = child (Unicode)"
+        (remainingPathShouldBe
+          $(mkAbsDir "\\\\?\\C:\\folder\\")
+         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "bob\\foo.txt"))
+         (Just $(mkRelFile "bob\\foo.txt")))
      it "stripProperPrefix parent parent = _|_"
-        (stripProperPrefix $(mkAbsDir "C:\\home\\chris\\foo")
-                  $(mkAbsDir "C:\\home\\chris\\foo") ==
-         Nothing)
+        (remainingPathShouldBe
+          $(mkAbsDir "C:\\home\\chris\\foo")
+          $(mkAbsDir "C:\\home\\chris\\foo")
+          Nothing)
+  where remainingPathShouldBe prefix path suffix =
+          stripProperPrefix prefix path == suffix
 
 -- | The '</>' operation.
 operationAppend :: Spec
 operationAppend =
   do it "AbsDir + RelDir = AbsDir"
-        ($(mkAbsDir "C:\\home\\") </>
-         $(mkRelDir "chris") ==
-         $(mkAbsDir "C:\\home\\chris\\"))
+        (shouldBe
+         ($(mkAbsDir "C:\\home\\") </> $(mkRelDir "chris"))
+          $(mkAbsDir "C:\\home\\chris\\"))
      it "AbsDir + RelFile = AbsFile"
-        ($(mkAbsDir "C:\\home\\") </>
-         $(mkRelFile "chris\\test.txt") ==
-         $(mkAbsFile "C:\\home\\chris\\test.txt"))
+        (shouldBe
+         ($(mkAbsDir "C:\\home\\") </> $(mkRelFile "chris\\test.txt"))
+          $(mkAbsFile "C:\\home\\chris\\test.txt"))
      it "RelDir + RelDir = RelDir"
-        ($(mkRelDir "home\\") </>
-         $(mkRelDir "chris") ==
-         $(mkRelDir "home\\chris"))
+        (shouldBe
+         ($(mkRelDir "home\\") </> $(mkRelDir "chris"))
+          $(mkRelDir "home\\chris"))
      it ". + . = ."
-        ($(mkRelDir ".\\") </> $(mkRelDir ".") == $(mkRelDir "."))
+        (shouldBe
+         ($(mkRelDir ".\\") </> $(mkRelDir "."))
+          $(mkRelDir "."))
      it ". + x = x"
-        ($(mkRelDir ".") </> $(mkRelDir "x") == $(mkRelDir "x"))
+        (shouldBe
+         ($(mkRelDir ".") </> $(mkRelDir "x"))
+          $(mkRelDir "x"))
      it "x + . = x"
-        ($(mkRelDir "x") </> $(mkRelDir ".\\") == $(mkRelDir "x"))
+        (shouldBe
+         ($(mkRelDir "x") </> $(mkRelDir ".\\"))
+          $(mkRelDir "x"))
      it "RelDir + RelFile = RelFile"
-        ($(mkRelDir "home\\") </>
-         $(mkRelFile "chris\\test.txt") ==
-         $(mkRelFile "home\\chris\\test.txt"))
+        (shouldBe
+         ($(mkRelDir "home\\") </> $(mkRelFile "chris\\test.txt"))
+          $(mkRelFile "home\\chris\\test.txt"))
+     it "AbsDir(UNC) + RelDir = AbsDir(UNC)"
+        (shouldBe
+         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelDir "folder\\"))
+          $(mkAbsDir "\\\\host\\share\\folder\\"))
+     it "AbsDir(UNC) + RelFile = AbsFile(UNC)"
+        (shouldBe
+         ($(mkAbsDir "\\\\host\\share\\") </> $(mkRelFile "folder\\file.txt"))
+          $(mkAbsFile "\\\\host\\share\\folder\\file.txt"))
+     it "AbsDir(Unicode) + RelDir = AbsDir(Unicode)"
+        (shouldBe
+         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelDir "another\\"))
+          $(mkAbsDir "\\\\?\\C:\\folder\\another\\"))
+     it "AbsDir(Unicode) + RelFile = AbsFile(Unicode)"
+        (shouldBe
+         ($(mkAbsDir "\\\\?\\C:\\folder\\") </> $(mkRelFile "file.txt"))
+          $(mkAbsFile "\\\\?\\C:\\folder\\file.txt"))
 
 operationToFilePath :: Spec
 operationToFilePath =

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -190,6 +190,12 @@ parseAbsDirSpec =
      succeeding "C:\\\\\\foo\\\\bar\\\\mu\\" (Path "C:\\foo\\bar\\mu\\")
      succeeding "C:\\\\\\foo\\\\bar\\\\mu" (Path "C:\\foo\\bar\\mu\\")
      succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu" (Path "C:\\foo\\bar\\mu\\")
+     succeeding "\\\\unchost\\share" (Path "\\\\unchost\\share\\")
+     succeeding "\\/unchost\\share" (Path "\\\\unchost\\share\\")
+     succeeding "\\\\unchost\\share\\\\folder\\" (Path "\\\\unchost\\share\\folder\\")
+     succeeding "\\\\?\\C:\\" (Path "\\\\?\\C:\\")
+     succeeding "/\\?\\C:\\" (Path "\\\\?\\C:\\")
+     succeeding "\\\\?\\C:\\\\\\folder\\\\" (Path "\\\\?\\C:\\folder\\")
 
   where failing x = parserTest parseAbsDir x Nothing
         succeeding x with = parserTest parseAbsDir x (Just with)
@@ -205,6 +211,8 @@ parseRelDirSpec =
      failing "\\\\\\foo\\\\bar\\\\mu\\"
      failing "\\\\\\foo\\\\bar\\\\\\\\mu"
      failing "\\\\\\foo\\\\bar\\.\\\\mu"
+     failing "\\\\unchost\\share"
+     failing "\\\\?\\C:\\"
      succeeding ".\\" (Path "")
      succeeding ".\\.\\" (Path "")
      succeeding "..." (Path "...\\")
@@ -235,6 +243,12 @@ parseAbsFileSpec =
      failing "\\foo.txt"
      succeeding "C:\\\\\\foo\\\\bar\\\\\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt")
      succeeding "C:\\\\\\foo\\\\bar\\.\\\\mu.txt" (Path "C:\\foo\\bar\\mu.txt")
+     succeeding "\\\\unchost\\share\\\\file.txt" (Path "\\\\unchost\\share\\file.txt")
+     succeeding "\\/unchost\\share\\\\file.txt" (Path "\\\\unchost\\share\\file.txt")
+     succeeding "\\\\unchost\\share\\.\\folder\\\\\\file.txt" (Path "\\\\unchost\\share\\folder\\file.txt")
+     succeeding "\\\\?\\C:\\file.txt" (Path "\\\\?\\C:\\file.txt")
+     succeeding "/\\?\\C:\\file.txt" (Path "\\\\?\\C:\\file.txt")
+     succeeding "\\\\?\\C:\\\\\\folder\\.\\\\file.txt" (Path "\\\\?\\C:\\folder\\file.txt")
 
   where failing x = parserTest parseAbsFile x Nothing
         succeeding x with = parserTest parseAbsFile x (Just with)
@@ -256,6 +270,8 @@ parseRelFileSpec =
      failing "\\\\\\foo\\\\bar\\\\mu\\"
      failing "\\\\\\foo\\\\bar\\\\\\\\mu"
      failing "\\\\\\foo\\\\bar\\.\\\\mu"
+     failing "\\\\unchost\\share\\\\file.txt"
+     failing "\\\\?\\C:\\file.txt"
      succeeding "a.." (Path "a..")
      succeeding "..." (Path "...")
      succeeding "foo.txt" (Path "foo.txt")


### PR DESCRIPTION
Fixes #81

In this PR:
* Added path separator de-duplication when normalizing paths on Windows, and at the tail of the drive.
  * On Posix, it still de-dupes consecutive slashes at the beginning of the path as before.
* Added check in `parseRelDir` that path is not all path separators (that's an absolute path on Posix and Windows).
* Removed test that asserted success when parsing `~/` on Windows as that's not a Windows thing.
* Changed a couple of relative dir path examples from successful to failing for paths that start with separators as that makes them absolute paths.
* Added handling of UNC (`\\host\share`) and Unicode (`\\?\C:\`) paths on Windows and tests for these types of paths