### PR TITLE
(WIP) Fix validity tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ test_script:
 - stack setup > nul
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench --test :test
+- echo "" | stack --no-terminal build --haddock --no-haddock-deps --bench --test :test :validity-test

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -260,7 +260,7 @@ relfile = qq mkRelFile
 --
 infixr 5 </>
 (</>) :: Path b Dir -> Path Rel t -> Path b t
-(</>) (Path a) (Path b) = Path (a ++ dropWhile FilePath.isPathSeparator b)
+(</>) (Path a) (Path b) = Path (a ++ b)
 
 -- | If the directory in the first argument is a proper prefix of the path in
 -- the second argument strip it from the second argument, generating a path

--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -260,7 +260,7 @@ relfile = qq mkRelFile
 --
 infixr 5 </>
 (</>) :: Path b Dir -> Path Rel t -> Path b t
-(</>) (Path a) (Path b) = Path (a ++ b)
+(</>) (Path a) (Path b) = Path (a ++ dropWhile FilePath.isPathSeparator b)
 
 -- | If the directory in the first argument is a proper prefix of the path in
 -- the second argument strip it from the second argument, generating a path


### PR DESCRIPTION
Fixes #74

Opening PR to see what happens in CI, validity-tests keep hanging on my machine.

As [mentioned in the issue](https://github.com/commercialhaskell/path/issues/74#issuecomment-284864707), the `</>` operator simply concat's its arguments, not accounting for extra slashes.

I tried just adding `dropWhile FilePath.isPathSeparator` to the right-hand argument and then concat'ing and this may have fixed some of the failures.

This could be taken further by having `</>` always normalize the result of the concat so all of this library's operators return normalized paths.