### PR TITLE
(WIP) Export isValid* functions

### DIFF
--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -17,17 +17,40 @@ import           Data.GenValidity
 
 import           Test.QuickCheck
 
+
 instance Validity (Path Abs File) where
-  isValid = isValidAbsFile . toFilePath
+  isValid p@(Path fp)
+    =  FilePath.isAbsolute fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+    && FilePath.isValid fp
+    && not (hasParentDir fp)
+    && (parseAbsFile fp == Just p)
 
 instance Validity (Path Rel File) where
-  isValid = isValidRelFile . toFilePath
+  isValid p@(Path fp)
+    =  FilePath.isRelative fp
+    && not (FilePath.hasTrailingPathSeparator fp)
+    && FilePath.isValid fp
+    && fp /= "."
+    && not (hasParentDir fp)
+    && (parseRelFile fp == Just p)
 
 instance Validity (Path Abs Dir) where
-  isValid = isValidAbsDir . toFilePath
+  isValid p@(Path fp)
+    =  FilePath.isAbsolute fp
+    && FilePath.hasTrailingPathSeparator fp
+    && FilePath.isValid fp
+    && not (hasParentDir fp)
+    && (parseAbsDir fp == Just p)
 
 instance Validity (Path Rel Dir) where
-  isValid = isValidRelDir . toFilePath
+  isValid p =
+    FilePath.isRelative fp
+    && FilePath.hasTrailingPathSeparator fp
+    && FilePath.isValid fp
+    && not (hasParentDir fp)
+    && (parseRelDir fp == Just p)
+    where fp = toFilePath p
 
 instance GenUnchecked (Path Abs File) where
   genUnchecked = Path <$> genFilePath

--- a/test/Path/Gen.hs
+++ b/test/Path/Gen.hs
@@ -17,40 +17,17 @@ import           Data.GenValidity
 
 import           Test.QuickCheck
 
-
 instance Validity (Path Abs File) where
-  isValid p@(Path fp)
-    =  FilePath.isAbsolute fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseAbsFile fp == Just p)
+  isValid = isValidAbsFile . toFilePath
 
 instance Validity (Path Rel File) where
-  isValid p@(Path fp)
-    =  FilePath.isRelative fp
-    && not (FilePath.hasTrailingPathSeparator fp)
-    && FilePath.isValid fp
-    && fp /= "."
-    && not (hasParentDir fp)
-    && (parseRelFile fp == Just p)
+  isValid = isValidRelFile . toFilePath
 
 instance Validity (Path Abs Dir) where
-  isValid p@(Path fp)
-    =  FilePath.isAbsolute fp
-    && FilePath.hasTrailingPathSeparator fp
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseAbsDir fp == Just p)
+  isValid = isValidAbsDir . toFilePath
 
 instance Validity (Path Rel Dir) where
-  isValid p =
-    FilePath.isRelative fp
-    && FilePath.hasTrailingPathSeparator fp
-    && FilePath.isValid fp
-    && not (hasParentDir fp)
-    && (parseRelDir fp == Just p)
-    where fp = toFilePath p
+  isValid = isValidRelDir . toFilePath
 
 instance GenUnchecked (Path Abs File) where
   genUnchecked = Path <$> genFilePath

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -33,12 +33,12 @@ spec = parallel $ do
      describe "Parsing: Path Rel Dir" (parserSpec parseRelDir)
      describe "Parsing: Path Abs File" (parserSpec parseAbsFile)
      describe "Parsing: Path Rel File" (parserSpec parseRelFile)
-     -- describe "Operations: (</>)" operationAppend
-     -- describe "Operations: stripProperPrefix" operationStripDir
-     -- describe "Operations: isProperPrefixOf" operationIsParentOf
-     -- describe "Operations: parent" operationParent
-     -- describe "Operations: filename" operationFilename
-     -- describe "Extensions" extensionsSpec
+     describe "Operations: (</>)" operationAppend
+     describe "Operations: stripProperPrefix" operationStripDir
+     describe "Operations: isProperPrefixOf" operationIsParentOf
+     describe "Operations: parent" operationParent
+     describe "Operations: filename" operationFilename
+     describe "Extensions" extensionsSpec
 
 -- | The 'filename' operation.
 operationFilename :: Spec

--- a/test/ValidityTest.hs
+++ b/test/ValidityTest.hs
@@ -25,16 +25,20 @@ main = hspec spec
 -- | Test suite.
 spec :: Spec
 spec = parallel $ do
+     describe "Validation: Path Abs Dir" (validationSpec isValidAbsDir parseAbsDir)
+     describe "Validation: Path Rel Dir" (validationSpec isValidRelDir parseRelDir)
+     describe "Validation: Path Abs File" (validationSpec isValidAbsFile parseAbsFile)
+     describe "Validation: Path Rel File" (validationSpec isValidRelFile parseRelFile)
      describe "Parsing: Path Abs Dir" (parserSpec parseAbsDir)
      describe "Parsing: Path Rel Dir" (parserSpec parseRelDir)
      describe "Parsing: Path Abs File" (parserSpec parseAbsFile)
      describe "Parsing: Path Rel File" (parserSpec parseRelFile)
-     describe "Operations: (</>)" operationAppend
-     describe "Operations: stripProperPrefix" operationStripDir
-     describe "Operations: isProperPrefixOf" operationIsParentOf
-     describe "Operations: parent" operationParent
-     describe "Operations: filename" operationFilename
-     describe "Extensions" extensionsSpec
+     -- describe "Operations: (</>)" operationAppend
+     -- describe "Operations: stripProperPrefix" operationStripDir
+     -- describe "Operations: isProperPrefixOf" operationIsParentOf
+     -- describe "Operations: parent" operationParent
+     -- describe "Operations: filename" operationFilename
+     -- describe "Extensions" extensionsSpec
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -213,5 +217,19 @@ extensionsSpec = do
 
 parserSpec :: (Show p, Validity p) => (FilePath -> Maybe p) -> Spec
 parserSpec parser =
-     it "Produces valid paths when it succeeds" $
+     it "produces valid paths when it succeeds" $
        validIfSucceedsOnGen parser genFilePath
+
+implies :: Bool -> Bool -> Bool
+implies True = id
+implies False = const True
+
+validationSpec :: Show p
+  => (FilePath -> Bool)
+  -> (FilePath -> Maybe p)
+  -> Spec
+validationSpec isValid parser =
+      it "returning True should guarantee path is parsable" $
+         forAllShrink genValid shrink validGuaranteesParsable
+    where
+      validGuaranteesParsable p = isValid p `shouldBe` isJust (parser p)


### PR DESCRIPTION
Fixes #133 

- [x] `is*` naming convention used
- [x] Renamed and exported existing `validAbsFile`, `validRelFile` functions
- [x] Added functions for `Abs Dir` and `Rel Dir`, factored out of `parseAbsDir`, `parseRelDir`
- [ ] Functions need to handle platform-specific validity
- [ ] Add/update tests
  - [ ] see if implementation of `Validity` instances can be replaced with these new functions
  - [x] If `isValid*` returns `True` for a `FilePath`, then the corresponding `parse*` function should succeed