### PR TITLE
Export SomeBase data constructor

### DIFF
--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -32,7 +32,7 @@ module Path.PLATFORM_NAME
   ,Rel
   ,File
   ,Dir
-  ,SomeBase
+  ,SomeBase(..)
    -- * Exceptions
   ,PathException(..)
   -- * QuasiQuoters


### PR DESCRIPTION
Following #140 PR, it misses the export of the data constructor. Otherwise there is not much we can do with `SomeBase`.