### PR TITLE
Fixes #159

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -51,6 +51,7 @@ test-suite test
   other-modules:     Posix
                    , Windows
                    , Common
+                   , TH
   hs-source-dirs:    test
   build-depends:     aeson
                    , base       >= 4.12     && < 5
@@ -59,6 +60,7 @@ test-suite test
                    , hspec      >= 2.0     && < 3
                    , mtl        >= 2.0     && < 3
                    , path
+                   , template-haskell
   if flag(dev)
     ghc-options:      -Wall -Werror
   else

--- a/test/TH.hs
+++ b/test/TH.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module TH where
+
+import qualified Language.Haskell.TH.Syntax as TH
+import Path
+import Path.Internal
+
+
+
+class Foo a b where
+    foo :: Path a b -> FilePath
+    foo = toFilePath
+
+instance Foo Abs Dir
+instance Foo Abs File
+instance Foo Rel Dir
+instance Foo Rel File
+
+
+
+qqAbsDir :: FilePath
+qqAbsDir = foo [absdir|/foo/|]
+
+qqAbsFile :: FilePath
+qqAbsFile = foo [absfile|/foo|]
+
+qqRelDir :: FilePath
+qqRelDir = foo [reldir|foo/|]
+
+qqRelFile :: FilePath
+qqRelFile = foo [relfile|foo|]
+
+thAbsDir :: FilePath
+thAbsDir = foo $(mkAbsDir "/foo/")
+
+thAbsFile :: FilePath
+thAbsFile = foo $(mkAbsFile "/foo")
+
+thRelDir :: FilePath
+thRelDir = foo $(mkRelDir "foo/")
+
+thRelFile :: FilePath
+thRelFile = foo $(mkRelFile "foo")
+
+liftAbsDir :: FilePath
+liftAbsDir = foo $(TH.lift (Path "/foo/" :: Path Abs Dir))
+
+liftAbsFile :: FilePath
+liftAbsFile = foo $(TH.lift (Path "/foo" :: Path Abs File))
+
+liftRelDir :: FilePath
+liftRelDir = foo $(TH.lift (Path "foo/" :: Path Rel Dir))
+
+liftRelFile :: FilePath
+liftRelFile = foo $(TH.lift (Path "foo" :: Path Rel File))

--- a/test/Windows.hs
+++ b/test/Windows.hs
@@ -11,7 +11,6 @@ import Control.Applicative
 import Control.Monad
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.Function (on)
 import Data.Maybe
 import Path.Windows
 import Path.Internal
@@ -82,7 +81,7 @@ operationDirname =
           $(mkRelDir "."))
      it "dirname C:\\ must be a Rel path"
         ((parseAbsDir $ show $ dirname (fromJust (parseAbsDir "C:\\")) :: Maybe (Path Abs Dir)) == Nothing)
-  where dirnamesShouldBeEqual = (==) `on` dirname
+  where dirnamesShouldBeEqual x y = dirname x == dirname y
 
 -- | The 'filename' operation.
 operationFilename :: Spec
@@ -103,7 +102,7 @@ operationFilename =
         (filenamesShouldBeEqual
           ($(mkAbsDir "\\\\?\\C:\\home\\chris\\") </> $(mkRelFile "bar.txt"))
           $(mkRelFile "bar.txt"))
-  where filenamesShouldBeEqual = (==) `on` filename
+  where filenamesShouldBeEqual x y = filename x == filename y
 
 -- | The 'parent' operation.
 operationParent :: Spec


### PR DESCRIPTION
Provided a path of type `Path a b` we use the `Typeable` instances of
`a` and `b` to insert the correct type in the splice.