### PR TITLE
Add MonadError in addition to MonadThrow.

### DIFF
--- a/path.cabal
+++ b/path.cabal
@@ -23,6 +23,9 @@ flag dev
 library
   hs-source-dirs:    src
   exposed-modules:   Path
+                   , Path.Except
+                   , Path.Except.Posix
+                   , Path.Except.Windows
                    , Path.Internal
                    , Path.Posix
                    , Path.Windows
@@ -32,6 +35,7 @@ library
                    , exceptions >= 0.4     && < 0.11
                    , filepath   < 1.2.0.1  || >= 1.3
                    , hashable   >= 1.2     && < 1.4
+                   , mtl
                    , text
                    , template-haskell
   if flag(dev)

--- a/src/Path/Except.hs
+++ b/src/Path/Except.hs
@@ -1,0 +1,15 @@
+-- | This library provides a well-typed representation of paths in a filesystem
+-- directory tree.
+--
+-- Both "Path.Posix" and "Path.Windows" provide the same interface. This
+-- module will reexport the appropriate module for your platform.
+
+{-# LANGUAGE CPP #-}
+
+#if defined(mingw32_HOST_OS)
+module Path.Except(module Path.Except.Windows) where
+import Path.Except.Windows
+#else
+module Path.Except(module Path.Except.Posix) where
+import Path.Except.Posix
+#endif

--- a/src/Path/Except/Posix.hs
+++ b/src/Path/Except/Posix.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE CPP #-}
+#define PREFIX          Path.Except
+#define PLATFORM_NAME   Posix
+#define IS_WINDOWS      False
+#define MONAD_PATH      MonadError PathException
+#define THROW           throwError
+#include "../Include.hs"

--- a/src/Path/Except/Windows.hs
+++ b/src/Path/Except/Windows.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE CPP #-}
+#define PREFIX          Path.Except
+#define PLATFORM_NAME   Windows
+#define IS_WINDOWS      True
+#define MONAD_PATH      MonadError PathException
+#define THROW           throwError
+#include "../Include.hs"

--- a/src/Path/Posix.hs
+++ b/src/Path/Posix.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+#define PREFIX          Path
 #define PLATFORM_NAME   Posix
 #define IS_WINDOWS      False
+#define MONAD_PATH      MonadThrow
+#define THROW           throwM
 #include "Include.hs"

--- a/src/Path/Windows.hs
+++ b/src/Path/Windows.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+#define PREFIX          Path
 #define PLATFORM_NAME   Windows
 #define IS_WINDOWS      True
+#define MONAD_PATH      MonadThrow
+#define THROW           throwM
 #include "Include.hs"


### PR DESCRIPTION
This abstracts Include.hs to be able to swap between `MonadError` and
`MonadThrow`. The `MonadError` implementations are exposed via
`Path.Except[.*]`, while `MonadThrow` remains in `Path[.*]`.

Some shortcomings and considerations:
- there is now a dependency on MTL
- `-Wunused-imports` is disabled so both classes can be imported
  without having to conditionalize anything
- there are no tests run against `Path.Except[.*]` yet

A slightly different approach could be to publish two packages -- `path`
and `path-except`. They would expose the exact same modules (`.Except`
would disappear), but one would have a dependency on `exceptions` and
the other on `mtl`. It's unlikely that anyone would want to use both the
MonadThrow and MonadError approaches in the same project, so this could
reduce their dependency footprint, but it does mean I have to fix the
unused imports.

Fixes #149.