### PR TITLE
Support for genvalidity >=1.0.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.4"]
         ghc:
-          - "8.6.5"
           - "8.8.4"
           - "8.10.4"
           - "9.0.1"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.9.1
+  * Support for genvalidity >=1.0.0.0
+
 0.9.0
   * Fix inconsistencies on different platforms: [#166](https://github.com/commercialhaskell/path/issues/166)
   * `replaceProperPrefix`

--- a/path.cabal
+++ b/path.cabal
@@ -81,7 +81,7 @@ test-suite validity-test
                    , base       >= 4.12 && < 5
                    , bytestring
                    , filepath   < 1.2.0.1  || >= 1.3
-                   , genvalidity >= 0.8
+                   , genvalidity >= 1.0
                    , genvalidity-property >= 0.4
                    , genvalidity-hspec >= 0.7
                    , hspec      >= 2.0     && < 3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,45 @@
-resolver: lts-16.12
+resolver: nightly-2021-11-19
+extra-deps:
+- github: NorfairKing/validity
+  commit: 35bc8d45b27e6c21429e4b681b16e46ccd541b3b
+  subdirs:
+    - genvalidity
+    - genvalidity-aeson
+    - genvalidity-bytestring
+    - genvalidity-containers
+    - genvalidity-criterion
+    - genvalidity-hspec
+    - genvalidity-hspec-aeson
+    - genvalidity-hspec-binary
+    - genvalidity-hspec-cereal
+    - genvalidity-hspec-hashable
+    - genvalidity-hspec-optics
+    - genvalidity-hspec-persistent
+    - genvalidity-path
+    - genvalidity-persistent
+    - genvalidity-property
+    - genvalidity-scientific
+    - genvalidity-sydtest
+    - genvalidity-sydtest-aeson
+    - genvalidity-sydtest-hashable
+    - genvalidity-sydtest-lens
+    - genvalidity-sydtest-persistent
+    - genvalidity-text
+    - genvalidity-time
+    - genvalidity-unordered-containers
+    - genvalidity-uuid
+    - genvalidity-vector
+    - validity
+    - validity-aeson
+    - validity-bytestring
+    - validity-containers
+    - validity-path
+    - validity-persistent
+    - validity-primitive
+    - validity-scientific
+    - validity-text
+    - validity-time
+    - validity-unordered-containers
+    - validity-uuid
+    - validity-vector
+

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,517 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    size: 113328
+    subdir: genvalidity
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 696
+      sha256: 5c65b0a9dff6c632330d7299a7bd956a1af0195f391164e392df08cb32c751a3
+  original:
+    subdir: genvalidity
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-aeson
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 464
+      sha256: 12c5a20c290b8416c47a6726510942eab95eecc77e53a7929224e10685f002e9
+  original:
+    subdir: genvalidity-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-bytestring
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-bytestring
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 485
+      sha256: 5d91f5d9be5264667c22b5986b4babf19bfe7a172e77b5223ea4b9a2f82468cc
+  original:
+    subdir: genvalidity-bytestring
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-containers
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 1014
+      sha256: 09951bbf1f9d59d8840c5e11c5cccfafecee586c8920c88057cafea32a6010b2
+  original:
+    subdir: genvalidity-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-criterion
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-criterion
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 351
+      sha256: 6cc53a130a14e997027565fe46251617dcab8037322ee35fb9abedcb68a3d914
+  original:
+    subdir: genvalidity-criterion
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 1982
+      sha256: 6a5a7dcfaaa41411e5b5ebfa9ca0ce0908636e92479c942abea243f87b622a7c
+  original:
+    subdir: genvalidity-hspec
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-aeson
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 463
+      sha256: de9003dbf94cb20de64404ae725e64bcdbcb2e70d835f4872c5a1c1565a33c8b
+  original:
+    subdir: genvalidity-hspec-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-binary
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-binary
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 417
+      sha256: e6dec8f52c4be1b1bcad2474ed0f618e463da1b308a6c98359aedb7271a821c7
+  original:
+    subdir: genvalidity-hspec-binary
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-cereal
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-cereal
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 466
+      sha256: fc09f7e1275cd7771b277abc2a7db8258894eec65d84e8e0650f3fd0cb88e02c
+  original:
+    subdir: genvalidity-hspec-cereal
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-hashable
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-hashable
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 424
+      sha256: 690addb83ef6b50a5c4061248bb618f87de918e4f06917a58ae05eae5915549d
+  original:
+    subdir: genvalidity-hspec-hashable
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-optics
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-optics
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 468
+      sha256: 0acd8f49e238904e9b815c17f579c31c3fdaa278b07a588dc7c20180a229c219
+  original:
+    subdir: genvalidity-hspec-optics
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-hspec-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-hspec-persistent
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 472
+      sha256: f8034acb7eb2640b6a370f3fe3a04b93a67ca856e6885d868f8b5b4a909cdfe1
+  original:
+    subdir: genvalidity-hspec-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-path
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-path
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 463
+      sha256: a7d76485ae6f2e1d7364e6c1a48bc2bc3ae68186db0f051a35b5d534e5f7d549
+  original:
+    subdir: genvalidity-path
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-persistent
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 478
+      sha256: 2fc53dec788ab2d42336ff7600b0564bee1ca38f0e9a2057a525b1a579f43c43
+  original:
+    subdir: genvalidity-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-property
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-property
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 2022
+      sha256: 494f91d56ffabd357064535a60f37f9cd33406e9f35743020a8355b12b2371e5
+  original:
+    subdir: genvalidity-property
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-scientific
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-scientific
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 428
+      sha256: 75c2a4abdf97a81d16c25ebc6870dd05f5920be9ce87f27cfe4039814833816a
+  original:
+    subdir: genvalidity-scientific
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-sydtest
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-sydtest
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 3914
+      sha256: 19f4e6e9d8372f741f40526b8079bd560b51e75dafd7cfddd1dab6929be8e02c
+  original:
+    subdir: genvalidity-sydtest
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-sydtest-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-sydtest-aeson
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 473
+      sha256: 24814fce1f4e0214fd08016bba642655b9de097978c192c370acc60847fc0dc2
+  original:
+    subdir: genvalidity-sydtest-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-sydtest-hashable
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-sydtest-hashable
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 434
+      sha256: a57c3322659385a568a7dc0ec6287c880b55f262ec82e2fab1e40f35c80be5d3
+  original:
+    subdir: genvalidity-sydtest-hashable
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-sydtest-lens
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-sydtest-lens
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 471
+      sha256: 95c9a71349325f30ce6536c443e82374ce723a720b552db39470d00531cb1d02
+  original:
+    subdir: genvalidity-sydtest-lens
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-sydtest-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-sydtest-persistent
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 482
+      sha256: b46e9ba5fe4eb2f9de4ee80b07dcfce710a1b04446d22b03b31af39a70130eb4
+  original:
+    subdir: genvalidity-sydtest-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-text
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-text
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 465
+      sha256: d7314329b29c95d141026184bc183a17ba6307624df1265649207310d910ab9e
+  original:
+    subdir: genvalidity-text
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-time
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-time
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 769
+      sha256: 1d21bb76d020c22c647412149b57f44d84e0a92d7d8beea101b4251a9e2000ec
+  original:
+    subdir: genvalidity-time
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-unordered-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-unordered-containers
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 595
+      sha256: a6696d2b5ffe9f3ef36704833bcd8fb8560e10cfb20924acc49b8c5492825239
+  original:
+    subdir: genvalidity-unordered-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-uuid
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-uuid
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 463
+      sha256: a9171eef6b060658621afa9bb372fe53c88bb31f13d011b026f664b124d96c41
+  original:
+    subdir: genvalidity-uuid
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: genvalidity-vector
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: genvalidity-vector
+    version: 1.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 413
+      sha256: 6cba82bf53112716b23101d3e587034891a2a7133cd23cceb088dbea00e0fcf5
+  original:
+    subdir: genvalidity-vector
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity
+    version: 0.12.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 391
+      sha256: 9cc065944d50877134d487f454c6e2a686a7dc87a6d347c0ff364daef5b4daa1
+  original:
+    subdir: validity
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-aeson
+    version: 0.2.0.4
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 405
+      sha256: d9b024cc35724f907ce31f130a5a86c64f8e3a06f09e26448aa36be88e8fa14b
+  original:
+    subdir: validity-aeson
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-bytestring
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-bytestring
+    version: 0.4.1.1
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 292
+      sha256: ba8cdeee52f1220338c333a19040414cc57fcb0502e79c3db511aa05d0c38474
+  original:
+    subdir: validity-bytestring
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-containers
+    version: 0.5.0.4
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 554
+      sha256: 0c2587e641fb93c272a61af7de6f6fb93f8e68eecd541792eaf61a95757a10aa
+  original:
+    subdir: validity-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-path
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-path
+    version: 0.4.0.1
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 403
+      sha256: 08a1830f96825bebfa8f5dab6db2df13348e17eba5b589a2ef52b2e5137f32e8
+  original:
+    subdir: validity-path
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-persistent
+    version: 0.0.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 285
+      sha256: 3bd3e2c517817dd9fa3f5d4698321f6a72a59ea2608f609cb460abdb1ebccb42
+  original:
+    subdir: validity-persistent
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-primitive
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-primitive
+    version: 0.0.0.1
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 288
+      sha256: 25639d2ab249e5181175bc9696625007e3ef22e56655fa78b37eaa5c326b9900
+  original:
+    subdir: validity-primitive
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-scientific
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-scientific
+    version: 0.2.0.3
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 290
+      sha256: a82ffae296b56a81572086aec3f6ac439160492a408bce242fc0c8c478199208
+  original:
+    subdir: validity-scientific
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-text
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-text
+    version: 0.3.1.1
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 280
+      sha256: b0ee2826e523f0f98c4f93206da9bf63816999a937fa2d39a224be858236a71c
+  original:
+    subdir: validity-text
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-time
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-time
+    version: 0.4.0.0
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 573
+      sha256: 39b679643fd1598712074074133ee4d058bd8cc23432a71a7bafc574f46bbff1
+  original:
+    subdir: validity-time
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-unordered-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-unordered-containers
+    version: 0.2.0.3
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 446
+      sha256: 1fbbef6441fecc0803ab9ef11255120de2716e4cb9a79f5ef60385a38bb131b9
+  original:
+    subdir: validity-unordered-containers
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-uuid
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-uuid
+    version: 0.1.0.3
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 278
+      sha256: 5ffe191ef4812ea3910b25e80af18d367fadd3a4e95065facb7aa74c05a94fc0
+  original:
+    subdir: validity-uuid
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+- completed:
+    size: 113328
+    subdir: validity-vector
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
+    name: validity-vector
+    version: 0.2.0.3
+    sha256: a110d348c3020e85b3b92308f6e4ed0e644a61e9e35b24b75726edf33f598476
+    pantry-tree:
+      size: 282
+      sha256: e629550c5d2b3c4a7403514df00953664d3570b57bbf0dd6e9dcdd5aba787760
+  original:
+    subdir: validity-vector
+    url: https://github.com/NorfairKing/validity/archive/35bc8d45b27e6c21429e4b681b16e46ccd541b3b.tar.gz
 snapshots:
 - completed:
-    size: 532377
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/12.yaml
-    sha256: f914cfa23fef85bdf895e300a8234d9d0edc2dbec67f4bc9c53f85867c50eab6
-  original: lts-16.12
+    size: 596812
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/11/19.yaml
+    sha256: d4ebfabe1a2cc08a1521073ab0c9fd00036350518bfdd148ea7316690f39504d
+  original: nightly-2021-11-19


### PR DESCRIPTION
This change simplifies the validity-based testing and adds support for `genvalidity >= 1.0.0.0`.

I'll leave this here for a few days. If there is no pushback, and CI passes, then I'll go ahead and merge it.