### PR TITLE
Make Rel, Abs, File and Dir instances of Data

### DIFF
--- a/src/Path/Include.hs
+++ b/src/Path/Include.hs
@@ -120,17 +120,17 @@ import qualified System.FilePath.PLATFORM_NAME as FilePath
 -- Types
 
 -- | An absolute path.
-data Abs deriving (Typeable)
+data Abs deriving (Typeable, Data)
 
 -- | A relative path; one without a root. Note that a @..@ path component to
 -- represent the parent directory is not allowed by this library.
-data Rel deriving (Typeable)
+data Rel deriving (Typeable, Data)
 
 -- | A file path.
-data File deriving (Typeable)
+data File deriving (Typeable, Data)
 
 -- | A directory path.
-data Dir deriving (Typeable)
+data Dir deriving (Typeable, Data)
 
 instance FromJSON (Path Abs File) where
   parseJSON = parseJSONWith parseAbsFile


### PR DESCRIPTION
As I describe in https://github.com/commercialhaskell/path/issues/186, this would enable `Path Rel Dir`, `Path Rel File`, and so on, to also be instances of `Data`, which enables any other data type that uses `Path` as part of its structure to also easily derive `Data`.