### PR TITLE
Additional OsPath/OsString implementation for Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ cabal.project.local
 cabal.sandbox.config
 dist-*/
 dist/
+.direnv
+.pre-commit-config.yaml
+result

--- a/path/default.nix
+++ b/path/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "path";
-  version = "0.9.6";
+  version = "0.9.7";
   src = ./.;
   libraryHaskellDepends = [
     aeson base deepseq exceptions filepath hashable template-haskell

--- a/path/os-string-compat/System/OsString/Compat/Include.hs
+++ b/path/os-string-compat/System/OsString/Compat/Include.hs
@@ -6,6 +6,7 @@
 
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -18,42 +19,62 @@
 #endif
 #endif
 
-module System.OsString.Compat.PLATFORM_NAME
+#ifndef MODULE_NAME
+#define MODULE_NAME System.OsString.Compat.PLATFORM_NAME
+#endif
+
+module MODULE_NAME
 #if USE_os_string
   ( PLATFORM_STRING(..)
   , PLATFORM_CHAR(..)
   , module OsString
+#ifdef ALTERNATE_OSSTRING_PSTR
+  , pstr
+#endif
   )
 #else
   ( PLATFORM_STRING(..)
   , PLATFORM_CHAR(..)
+#ifndef ALTERNATE_OSSTRING_PSTR
   , OsString.pstr
-  , System.OsString.Compat.PLATFORM_NAME.all
-  , System.OsString.Compat.PLATFORM_NAME.any
-  , System.OsString.Compat.PLATFORM_NAME.break
-  , System.OsString.Compat.PLATFORM_NAME.breakEnd
-  , System.OsString.Compat.PLATFORM_NAME.dropWhileEnd
-  , System.OsString.Compat.PLATFORM_NAME.empty
-  , System.OsString.Compat.PLATFORM_NAME.init
-  , System.OsString.Compat.PLATFORM_NAME.isInfixOf
-  , System.OsString.Compat.PLATFORM_NAME.isPrefixOf
-  , System.OsString.Compat.PLATFORM_NAME.isSuffixOf
-  , System.OsString.Compat.PLATFORM_NAME.length
-  , System.OsString.Compat.PLATFORM_NAME.map
-  , System.OsString.Compat.PLATFORM_NAME.null
-  , System.OsString.Compat.PLATFORM_NAME.replicate
-  , System.OsString.Compat.PLATFORM_NAME.singleton
-  , System.OsString.Compat.PLATFORM_NAME.span
-  , System.OsString.Compat.PLATFORM_NAME.spanEnd
-  , System.OsString.Compat.PLATFORM_NAME.stripPrefix
-  , System.OsString.Compat.PLATFORM_NAME.uncons
+#else
+  , pstr
+#endif
+  , MODULE_NAME.all
+  , MODULE_NAME.any
+  , MODULE_NAME.break
+  , MODULE_NAME.breakEnd
+  , MODULE_NAME.dropWhileEnd
+  , MODULE_NAME.empty
+  , MODULE_NAME.init
+  , MODULE_NAME.isInfixOf
+  , MODULE_NAME.isPrefixOf
+  , MODULE_NAME.isSuffixOf
+  , MODULE_NAME.length
+  , MODULE_NAME.map
+  , MODULE_NAME.null
+  , MODULE_NAME.replicate
+  , MODULE_NAME.singleton
+  , MODULE_NAME.span
+  , MODULE_NAME.spanEnd
+  , MODULE_NAME.stripPrefix
+  , MODULE_NAME.uncons
   )
 #endif
   where
 
 import Data.Data (Data)
+#ifdef EXTRA_DATA_DERIVATION
+import System.OsString.Internal.Types (PLATFORM_STRING(..), PLATFORM_CHAR(..), EXTRA_DATA_DERIVATION)
+#else
 import System.OsString.Internal.Types (PLATFORM_STRING(..), PLATFORM_CHAR(..))
-import System.OsString.PLATFORM_NAME as OsString
+#endif
+
+#ifndef OSSTRING_MODULE
+#define OSSTRING_MODULE System.OsString.PLATFORM_NAME
+#endif
+
+import OSSTRING_MODULE as OsString
 
 #if !USE_os_string
 import Data.Coerce (coerce)
@@ -65,9 +86,27 @@ import qualified System.OsPath.Data.ByteString.Short as BSP
 #endif
 #endif
 
+#ifdef EXPOSE_CONSTRUCTOR_MODULE
+import qualified EXPOSE_CONSTRUCTOR_MODULE
+#endif
+
+#ifdef ALTERNATE_OSSTRING_PSTR
+import Language.Haskell.TH.Quote (QuasiQuoter)
+#endif
+
+#ifdef EXTRA_DATA_DERIVATION
+deriving instance Data EXTRA_DATA_DERIVATION
+#endif
+
 deriving instance Data PLATFORM_STRING
 
+#ifdef ALTERNATE_OSSTRING_PSTR
+pstr :: QuasiQuoter
+pstr = ALTERNATE_OSSTRING_PSTR
+#endif
+
 #if !USE_os_string
+
 all :: (PLATFORM_CHAR -> Bool) -> PLATFORM_STRING -> Bool
 all = coerce BSP.all
 

--- a/path/os-string-compat/System/OsString/Compat/OsString.hs
+++ b/path/os-string-compat/System/OsString/Compat/OsString.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+
+#define PLATFORM_NAME        OsString
+#define OSSTRING_MODULE      System.OsString
+#define PLATFORM_STRING      OsString
+#define PLATFORM_CHAR        OsChar
+#define MODULE_NAME          System.OsString.Compat.OsString
+#define EXPOSE_CONSTRUCTOR_MODULE System.OsString.Internal.Types
+#define EXTRA_DATA_DERIVATION PlatformString
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+#define IS_WINDOWS           1
+#else
+#define IS_WINDOWS           0
+#endif
+
+#define ALTERNATE_OSSTRING_PSTR       OsString.osstr
+
+#include "Include.hs"

--- a/path/path.cabal
+++ b/path/path.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                path
-version:             0.9.6
+version:             0.9.7
 synopsis:            Support for well-typed paths
 description:         Support for well-typed paths.
 license:             BSD-3-Clause
@@ -66,9 +66,13 @@ library
                    , OsPath
                    , OsPath.Posix
                    , OsPath.Windows
+                   , OsPath.OsString
                    , OsPath.Internal
                    , OsPath.Internal.Posix
                    , OsPath.Internal.Windows
+                   , OsPath.Internal.OsString
+  
+  other-modules:     OsPath.Internal.OsPathWrapper
 
   build-depends:     aeson      >= 1.0.0.0
                    , base       >= 4.12    && < 5
@@ -92,9 +96,11 @@ library os-string-compat
 
   exposed-modules:   System.OsString.Compat.Posix
                    , System.OsString.Compat.Windows
+                   , System.OsString.Compat.OsString
 
   build-depends:     base       >= 4.12    && < 5
-
+                   , template-haskell
+                  
   if flag(os-string)
     build-depends:   os-string  >= 2.0.0
   else

--- a/path/src/OsPath/Include.hs
+++ b/path/src/OsPath/Include.hs
@@ -115,8 +115,12 @@ import           GHC.Generics (Generic)
 import           Language.Haskell.TH (Exp, Q)
 import           Language.Haskell.TH.Syntax (lift)
 import           Language.Haskell.TH.Quote (QuasiQuoter(..))
-import           System.OsPath.PLATFORM_NAME (PLATFORM_PATH)
-import qualified System.OsPath.PLATFORM_NAME as OsPath
+
+#ifndef OSPATH_MODULE
+#define OSPATH_MODULE System.OsPath.PLATFORM_NAME
+#endif
+import           OSPATH_MODULE (PLATFORM_PATH)
+import qualified OSPATH_MODULE as OsPath
 
 import           OsPath.Internal.PLATFORM_NAME
 import           System.OsString.Compat.PLATFORM_NAME (PLATFORM_STRING)

--- a/path/src/OsPath/Internal/Include.hs
+++ b/path/src/OsPath/Internal/Include.hs
@@ -13,7 +13,10 @@
 
 -- | Internal types and functions.
 
-module OsPath.Internal.PLATFORM_NAME
+#ifndef MODULE_NAME
+#define MODULE_NAME OsPath.Internal.PLATFORM_NAME
+#endif
+module MODULE_NAME
   ( -- * The Path type
     Path(..)
   , toOsPath
@@ -49,11 +52,18 @@ import GHC.Generics (Generic)
 import Data.Data
 import Data.Hashable
 import qualified Language.Haskell.TH.Syntax as TH
-import System.OsPath.PLATFORM_NAME (PLATFORM_PATH)
-import qualified System.OsPath.PLATFORM_NAME as OsPath
 
-import System.OsString.Compat.PLATFORM_NAME (PLATFORM_STRING)
-import qualified System.OsString.Compat.PLATFORM_NAME as OsString
+#ifndef OSPATH_MODULE
+#define OSPATH_MODULE System.OsPath.PLATFORM_NAME
+#endif
+import OSPATH_MODULE (PLATFORM_PATH)
+import qualified OSPATH_MODULE as OsPath
+
+#ifndef OSSTRING_COMPAT_MODULE
+#define OSSTRING_COMPAT_MODULE System.OsString.Compat.PLATFORM_NAME
+#endif
+import OSSTRING_COMPAT_MODULE (PLATFORM_STRING)
+import qualified OSSTRING_COMPAT_MODULE as OsString
 
 -- | Path of some base and type.
 --

--- a/path/src/OsPath/Internal/OsPathWrapper.hs
+++ b/path/src/OsPath/Internal/OsPathWrapper.hs
@@ -1,0 +1,13 @@
+{-
+Include.hs expects the quasiquoter to be named 'pstr', however despite the fact that both
+System.OsPath.Posix and System.OsPath.Windows export a quasiquoter named 'pstr',
+System.OsPath names it 'osp'. So we just re-export with a different name.
+-}
+module OsPath.Internal.OsPathWrapper (module System.OsPath, pstr) where
+
+import System.OsPath hiding (osp)
+import qualified System.OsPath
+import Language.Haskell.TH.Quote (QuasiQuoter)
+
+pstr :: QuasiQuoter
+pstr = System.OsPath.osp

--- a/path/src/OsPath/Internal/OsString.hs
+++ b/path/src/OsPath/Internal/OsString.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+
+#define MODULE_NAME          OsPath.Internal.OsString
+#define PLATFORM_NAME        OsString
+#define OSPATH_MODULE        OsPath.Internal.OsPathWrapper
+#define OSSTRING_MODULE      System.OsString
+#define PLATFORM_PATH        OsPath
+#define PLATFORM_PATH_SINGLE 'OsPath'
+#define PLATFORM_STRING      OsString
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+#define IS_WINDOWS           1
+#else
+#define IS_WINDOWS           0
+#endif
+
+#include "Include.hs"

--- a/path/src/OsPath/OsString.hs
+++ b/path/src/OsPath/OsString.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+
+#define PLATFORM_NAME        OsString
+#define PLATFORM_PATH        OsPath
+#define PLATFORM_PATH_SINGLE 'OsPath'
+#define PLATFORM_STRING      OsString
+#define OSPATH_MODULE        System.OsPath
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+#define IS_WINDOWS           1
+#define PLATFORM_UTF_CODEC   UTF16-LE
+#else
+#define IS_WINDOWS           0
+#define PLATFORM_UTF_CODEC   UTF8
+#endif
+
+#include "Include.hs"


### PR DESCRIPTION
[`OsPath.Posix`](https://hackage.haskell.org/package/path-0.9.6/docs/OsPath-Posix.html) and [`OsPath.Windows`](https://hackage.haskell.org/package/path-0.9.6/docs/OsPath-Windows.html) have in their APIs references to [`PosixPath`](https://hackage.haskell.org/package/filepath-1.5.3.0/docs/System-OsPath-Types.html#t:PosixPath) and [`WindowsPath`](https://hackage.haskell.org/package/filepath-1.5.3.0/docs/System-OsPath-Types.html#t:WindowsPath) respectively.

Other libraries tend to use [`OsPath`](https://hackage.haskell.org/package/filepath-1.5.3.0/docs/System-OsPath-Types.html#t:OsPath), which is just a type alias for [`OsString`](https://hackage.haskell.org/package/os-string-2.0.4/docs/System-OsString-Internal-Types.html), but `OsString` is not a type alias for `PosixPath`/`WindowsPath`, it's a newtype wrapper. Hence interacting with libraries which use `OsPath`/`OsString` as their underlying type is a bit of a pain.

So this PR adds an `OsPath.OsString` module, much like `OsPath.Posix` and `OsPath.Windows` which already exist.

The nice thing about `OsPath.OsString` is that code written against it works on both Posix and Windows, whereas code written against `OsPath.Posix` would need to have it's module imports changed to work on Windows and via versa for code written against `OsPath.Windows`. Whilst this is relatively trivial it does mean that one can't make platform independent code with this library currently. But with `OsPath.OsString` is actually multiplatform unlike the alternatives and should be able to be run on Windows and Posix without code changes.

I haven't really fleshed out test cases but I have got this working on an internal project. If you're happy with the general direction of the PR I'm happy to take the time to add the test cases as you think appropriate.

(Oh I just noticed this basically implements https://github.com/commercialhaskell/path/issues/197)
